### PR TITLE
Fixed XP val bug disrupting quest completion/rewards

### DIFF
--- a/ReQuest/ui/gm/modals.py
+++ b/ReQuest/ui/gm/modals.py
@@ -270,9 +270,8 @@ class RewardsModal(Modal):
         else:
             rewards = calling_view.current_individual_rewards
 
-        xp_default = ''
-        if rewards.get('xp') is not None:
-            xp_default = str(rewards['xp'])
+        xp_value = rewards.get('xp')
+        xp_default = str(xp_value) if xp_value is not None else '0'
 
         items_default = ''
         if rewards.get('items'):
@@ -302,7 +301,7 @@ class RewardsModal(Modal):
 
     async def on_submit(self, interaction: discord.Interaction):
         try:
-            xp = None
+            xp = 0
             items = None
             if self.xp_input.value:
                 xp = int(self.xp_input.value)
@@ -379,7 +378,7 @@ class ModPlayerModal(Modal):
 
     async def on_submit(self, interaction: discord.Interaction):
         try:
-            xp = None
+            xp = 0
             gdb = interaction.client.gdb
             guild_id = interaction.guild_id
             currency_config = await gdb['currency'].find_one({'_id': guild_id})

--- a/ReQuest/ui/gm/views.py
+++ b/ReQuest/ui/gm/views.py
@@ -934,7 +934,8 @@ class CompleteQuestsView(LayoutView):
 
             # Get party members and message them with results
             reward_summary = []
-            party_xp = rewards.get('party', {}).get('xp', 0) // len(party)
+            party_xp = rewards.get('party', {}).get('xp', 0)
+            xp_per_member = party_xp // len(party)
             party_items = rewards.get('party', {}).get('items', {})
             for entry in party:
                 for player_id, character_info in entry.items():
@@ -946,7 +947,7 @@ class CompleteQuestsView(LayoutView):
                     reward_summary.append(f'<@!{player_id}> as {character['name']}:')
 
                     # Prep reward data
-                    total_xp = party_xp
+                    total_xp = xp_per_member
                     combined_items = party_items.copy()
 
                     # Check if character has individual rewards


### PR DESCRIPTION
This PR fixes #77 by ensuring integers are used when reading/writing XP rewards.