### PR TITLE
Add configurable quest role modes. Add supporting UI pages and revamp…

### DIFF
--- a/ReQuest/locales/bg/config.ftl
+++ b/ReQuest/locales/bg/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/bg/config.ftl
+++ b/ReQuest/locales/bg/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/bg/config.ftl
+++ b/ReQuest/locales/bg/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Език на сървъра:{"**"}
 config-select-placeholder-server-language = Изберете език на сървъра
 config-select-option-default = По подразбиране (без промяна)
 config-select-desc-default = Използване на предпочитанието на всеки потребител или езика на Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/bg/config.ftl
+++ b/ReQuest/locales/bg/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/bg/gm.ftl
+++ b/ReQuest/locales/bg/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/bg/gm.ftl
+++ b/ReQuest/locales/bg/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Обновяването на инвентара е о
 gm-embed-desc-approved = Инвентарът за {"**"}{ $characterName }{"**"} беше одобрен от { $approver }.
 gm-embed-title-denied = Обновяването на инвентара е отхвърлено
 gm-embed-desc-denied = Инвентарът за {"**"}{ $characterName }{"**"} беше отхвърлен от { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/bg/gm.ftl
+++ b/ReQuest/locales/bg/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/bg/gm.ftl
+++ b/ReQuest/locales/bg/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/cs/config.ftl
+++ b/ReQuest/locales/cs/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/cs/config.ftl
+++ b/ReQuest/locales/cs/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/cs/config.ftl
+++ b/ReQuest/locales/cs/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Jazyk serveru:{"**"} Výchozí (bez
 config-select-placeholder-server-language = Vyberte jazyk serveru
 config-select-option-default = Výchozí (bez přepsání)
 config-select-desc-default = Použít preference každého uživatele nebo jazyk Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/cs/config.ftl
+++ b/ReQuest/locales/cs/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/cs/gm.ftl
+++ b/ReQuest/locales/cs/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/cs/gm.ftl
+++ b/ReQuest/locales/cs/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/cs/gm.ftl
+++ b/ReQuest/locales/cs/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Aktualizace inventáře schválena
 gm-embed-desc-approved = Inventář pro {"**"}{ $characterName }{"**"} byl schválen uživatelem { $approver }.
 gm-embed-title-denied = Aktualizace inventáře zamítnuta
 gm-embed-desc-denied = Inventář pro {"**"}{ $characterName }{"**"} byl zamítnut uživatelem { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/cs/gm.ftl
+++ b/ReQuest/locales/cs/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/da/config.ftl
+++ b/ReQuest/locales/da/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/da/config.ftl
+++ b/ReQuest/locales/da/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/da/config.ftl
+++ b/ReQuest/locales/da/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/da/config.ftl
+++ b/ReQuest/locales/da/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Serversprog:{"**"} Standard (ingen 
 config-select-placeholder-server-language = Vælg serversprog
 config-select-option-default = Standard (ingen tilsidesættelse)
 config-select-desc-default = Brug hver brugers præference eller Discord-sprog.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/da/gm.ftl
+++ b/ReQuest/locales/da/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/da/gm.ftl
+++ b/ReQuest/locales/da/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/da/gm.ftl
+++ b/ReQuest/locales/da/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/da/gm.ftl
+++ b/ReQuest/locales/da/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Inventaropdatering godkendt
 gm-embed-desc-approved = Inventaret for {"**"}{ $characterName }{"**"} er blevet godkendt af { $approver }.
 gm-embed-title-denied = Inventaropdatering afvist
 gm-embed-desc-denied = Inventaret for {"**"}{ $characterName }{"**"} er blevet afvist af { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/de/config.ftl
+++ b/ReQuest/locales/de/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/de/config.ftl
+++ b/ReQuest/locales/de/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/de/config.ftl
+++ b/ReQuest/locales/de/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Serversprache:{"**"} Standard (kein
 config-select-placeholder-server-language = Serversprache auswählen
 config-select-option-default = Standard (keine Überschreibung)
 config-select-desc-default = Verwendet die Präferenz jedes Benutzers oder die Discord-Spracheinstellung.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/de/config.ftl
+++ b/ReQuest/locales/de/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/de/gm.ftl
+++ b/ReQuest/locales/de/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/de/gm.ftl
+++ b/ReQuest/locales/de/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/de/gm.ftl
+++ b/ReQuest/locales/de/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/de/gm.ftl
+++ b/ReQuest/locales/de/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Inventaraktualisierung genehmigt
 gm-embed-desc-approved = Das Inventar für {"**"}{ $characterName }{"**"} wurde von { $approver } genehmigt.
 gm-embed-title-denied = Inventaraktualisierung abgelehnt
 gm-embed-desc-denied = Das Inventar für {"**"}{ $characterName }{"**"} wurde von { $denier } abgelehnt.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/el/config.ftl
+++ b/ReQuest/locales/el/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/el/config.ftl
+++ b/ReQuest/locales/el/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/el/config.ftl
+++ b/ReQuest/locales/el/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/el/config.ftl
+++ b/ReQuest/locales/el/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Γλώσσα Διακομιστή:{
 config-select-placeholder-server-language = Επιλέξτε γλώσσα διακομιστή
 config-select-option-default = Προεπιλογή (χωρίς παράκαμψη)
 config-select-desc-default = Χρήση της προτίμησης κάθε χρήστη ή του Discord locale.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/el/gm.ftl
+++ b/ReQuest/locales/el/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/el/gm.ftl
+++ b/ReQuest/locales/el/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/el/gm.ftl
+++ b/ReQuest/locales/el/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Ενημέρωση Εξοπλισμού Εγκρίθη
 gm-embed-desc-approved = Ο εξοπλισμός του {"**"}{ $characterName }{"**"} εγκρίθηκε από τον/την { $approver }.
 gm-embed-title-denied = Ενημέρωση Εξοπλισμού Απορρίφθηκε
 gm-embed-desc-denied = Ο εξοπλισμός του {"**"}{ $characterName }{"**"} απορρίφθηκε από τον/την { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/el/gm.ftl
+++ b/ReQuest/locales/el/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/en-US/config.ftl
+++ b/ReQuest/locales/en-US/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/en-US/config.ftl
+++ b/ReQuest/locales/en-US/config.ftl
@@ -828,6 +828,7 @@ config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
 
 # AddGMQuestRoleSelect
 config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 
 ## Quest Roles View
 config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}

--- a/ReQuest/locales/en-US/config.ftl
+++ b/ReQuest/locales/en-US/config.ftl
@@ -78,9 +78,15 @@ config-btn-configure-rp-rewards = Configure RP Rewards
 config-btn-configure-shops = Configure Shops
 config-btn-new-char-setup = New Char Setup
 
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
 # Confirm modal titles (passed to common ConfirmModal)
 config-modal-title-confirm-role-removal = Confirm Role Removal
 config-modal-title-confirm-removal = Confirm Removal
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
 config-modal-title-confirm-currency-removal = Confirm Currency Removal
 config-modal-title-confirm-shop-removal = Confirm Shop Removal
 config-modal-title-confirm-kit-deletion = Confirm Kit Deletion
@@ -810,3 +816,42 @@ config-label-server-language-default = {"**"}Server Language:{"**"} Default (no 
 config-select-placeholder-server-language = Select server language
 config-select-option-default = Default (no override)
 config-select-desc-default = Use each user's preference or Discord locale.
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/en-US/config.ftl
+++ b/ReQuest/locales/en-US/config.ftl
@@ -829,6 +829,7 @@ config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
 # AddGMQuestRoleSelect
 config-select-placeholder-add-quest-role = Assign server role(s) to this GM
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
 
 ## Quest Roles View
 config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}

--- a/ReQuest/locales/en-US/gm.ftl
+++ b/ReQuest/locales/en-US/gm.ftl
@@ -97,6 +97,9 @@ gm-dm-rewards-no-active-character =
     quests. However, since you have no active character on this server, your rewards
     could not be automatically issued at this time.
 gm-dm-rewards-issued = The following has been awarded to your active character, { $characterName }
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.
 
 # GM select menus
 gm-select-placeholder-party-member = Select a party member

--- a/ReQuest/locales/en-US/gm.ftl
+++ b/ReQuest/locales/en-US/gm.ftl
@@ -68,7 +68,7 @@ gm-error-not-signed-up = You are not signed up for this quest.
 gm-error-quest-channel-not-set = Quest channel has not been set!
 gm-error-empty-roster = You cannot complete a quest with an empty roster. Try cancelling instead.
 gm-error-invalid-xp-value = XP value must be a positive integer!
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 
 # GM confirm modals
 gm-modal-title-cancel-quest = Cancel Quest

--- a/ReQuest/locales/en-US/gm.ftl
+++ b/ReQuest/locales/en-US/gm.ftl
@@ -100,6 +100,9 @@ gm-dm-rewards-issued = The following has been awarded to your active character, 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.
 
 # GM select menus
 gm-select-placeholder-party-member = Select a party member

--- a/ReQuest/locales/en-US/gm.ftl
+++ b/ReQuest/locales/en-US/gm.ftl
@@ -68,6 +68,7 @@ gm-error-not-signed-up = You are not signed up for this quest.
 gm-error-quest-channel-not-set = Quest channel has not been set!
 gm-error-empty-roster = You cannot complete a quest with an empty roster. Try cancelling instead.
 gm-error-invalid-xp-value = XP value must be a positive integer!
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
 
 # GM confirm modals
 gm-modal-title-cancel-quest = Cancel Quest
@@ -99,6 +100,9 @@ gm-dm-rewards-issued = The following has been awarded to your active character, 
 
 # GM select menus
 gm-select-placeholder-party-member = Select a party member
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
 
 # GM embeds
 gm-embed-title-mod-report = GM Player Modification Report

--- a/ReQuest/locales/es-419/config.ftl
+++ b/ReQuest/locales/es-419/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/es-419/config.ftl
+++ b/ReQuest/locales/es-419/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/es-419/config.ftl
+++ b/ReQuest/locales/es-419/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Idioma del Servidor:{"**"} Predeter
 config-select-placeholder-server-language = Selecciona el idioma del servidor
 config-select-option-default = Predeterminado (sin anulación)
 config-select-desc-default = Usa la preferencia de cada usuario o la configuración regional de Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/es-419/config.ftl
+++ b/ReQuest/locales/es-419/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/es-419/gm.ftl
+++ b/ReQuest/locales/es-419/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/es-419/gm.ftl
+++ b/ReQuest/locales/es-419/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/es-419/gm.ftl
+++ b/ReQuest/locales/es-419/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Actualización de Inventario Aprobada
 gm-embed-desc-approved = El inventario de {"**"}{ $characterName }{"**"} ha sido aprobado por { $approver }.
 gm-embed-title-denied = Actualización de Inventario Rechazada
 gm-embed-desc-denied = El inventario de {"**"}{ $characterName }{"**"} ha sido rechazado por { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/es-419/gm.ftl
+++ b/ReQuest/locales/es-419/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/es-ES/config.ftl
+++ b/ReQuest/locales/es-ES/config.ftl
@@ -702,3 +702,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/es-ES/config.ftl
+++ b/ReQuest/locales/es-ES/config.ftl
@@ -703,3 +703,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/es-ES/config.ftl
+++ b/ReQuest/locales/es-ES/config.ftl
@@ -704,3 +704,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/es-ES/config.ftl
+++ b/ReQuest/locales/es-ES/config.ftl
@@ -656,3 +656,49 @@ config-label-server-language-default = {"**"}Idioma del servidor:{"**"} Por defe
 config-select-placeholder-server-language = Seleccionad el idioma del servidor
 config-select-option-default = Por defecto (sin anulación)
 config-select-desc-default = Usar la preferencia de cada usuario o el idioma de Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/es-ES/gm.ftl
+++ b/ReQuest/locales/es-ES/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/es-ES/gm.ftl
+++ b/ReQuest/locales/es-ES/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/es-ES/gm.ftl
+++ b/ReQuest/locales/es-ES/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/es-ES/gm.ftl
+++ b/ReQuest/locales/es-ES/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Actualización de inventario aprobada
 gm-embed-desc-approved = El inventario de {"**"}{ $characterName }{"**"} ha sido aprobado por { $approver }.
 gm-embed-title-denied = Actualización de inventario rechazada
 gm-embed-desc-denied = El inventario de {"**"}{ $characterName }{"**"} ha sido rechazado por { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/fi/config.ftl
+++ b/ReQuest/locales/fi/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/fi/config.ftl
+++ b/ReQuest/locales/fi/config.ftl
@@ -859,3 +859,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/fi/config.ftl
+++ b/ReQuest/locales/fi/config.ftl
@@ -811,3 +811,49 @@ config-label-server-language-default = {"**"}Palvelimen kieli:{"**"} Oletus (ei 
 config-select-placeholder-server-language = Valitse palvelimen kieli
 config-select-option-default = Oletus (ei ohitusta)
 config-select-desc-default = Käytä kunkin käyttäjän omaa asetusta tai Discord-kieltä.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/fi/config.ftl
+++ b/ReQuest/locales/fi/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/fi/gm.ftl
+++ b/ReQuest/locales/fi/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/fi/gm.ftl
+++ b/ReQuest/locales/fi/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/fi/gm.ftl
+++ b/ReQuest/locales/fi/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Inventaarion päivitys hyväksytty
 gm-embed-desc-approved = Hahmon {"**"}{ $characterName }{"**"} inventaario on hyväksytty, hyväksyjä: { $approver }.
 gm-embed-title-denied = Inventaarion päivitys hylätty
 gm-embed-desc-denied = Hahmon {"**"}{ $characterName }{"**"} inventaario on hylätty, hylkääjä: { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/fi/gm.ftl
+++ b/ReQuest/locales/fi/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/fr/config.ftl
+++ b/ReQuest/locales/fr/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/fr/config.ftl
+++ b/ReQuest/locales/fr/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/fr/config.ftl
+++ b/ReQuest/locales/fr/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Langue du serveur :{"**"} Par défa
 config-select-placeholder-server-language = Sélectionnez la langue du serveur
 config-select-option-default = Par défaut (aucun remplacement)
 config-select-desc-default = Utiliser la préférence de chaque utilisateur ou la langue Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/fr/config.ftl
+++ b/ReQuest/locales/fr/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/fr/gm.ftl
+++ b/ReQuest/locales/fr/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/fr/gm.ftl
+++ b/ReQuest/locales/fr/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/fr/gm.ftl
+++ b/ReQuest/locales/fr/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/fr/gm.ftl
+++ b/ReQuest/locales/fr/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Mise à jour d'inventaire approuvée
 gm-embed-desc-approved = L'inventaire de {"**"}{ $characterName }{"**"} a été approuvé par { $approver }.
 gm-embed-title-denied = Mise à jour d'inventaire refusée
 gm-embed-desc-denied = L'inventaire de {"**"}{ $characterName }{"**"} a été refusé par { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/hi/config.ftl
+++ b/ReQuest/locales/hi/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}सर्वर भाषा:{"**"}
 config-select-placeholder-server-language = सर्वर भाषा चुनें
 config-select-option-default = डिफ़ॉल्ट (कोई ओवरराइड नहीं)
 config-select-desc-default = प्रत्येक उपयोगकर्ता की प्राथमिकता या Discord लोकेल का उपयोग करें।
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/hi/config.ftl
+++ b/ReQuest/locales/hi/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/hi/config.ftl
+++ b/ReQuest/locales/hi/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/hi/config.ftl
+++ b/ReQuest/locales/hi/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/hi/gm.ftl
+++ b/ReQuest/locales/hi/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/hi/gm.ftl
+++ b/ReQuest/locales/hi/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/hi/gm.ftl
+++ b/ReQuest/locales/hi/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/hi/gm.ftl
+++ b/ReQuest/locales/hi/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = सामान अपडेट स्वीकृत
 gm-embed-desc-approved = {"**"}{ $characterName }{"**"} का सामान { $approver } द्वारा स्वीकृत किया गया है।
 gm-embed-title-denied = सामान अपडेट अस्वीकृत
 gm-embed-desc-denied = {"**"}{ $characterName }{"**"} का सामान { $denier } द्वारा अस्वीकृत किया गया है।
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/hr/config.ftl
+++ b/ReQuest/locales/hr/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/hr/config.ftl
+++ b/ReQuest/locales/hr/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/hr/config.ftl
+++ b/ReQuest/locales/hr/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Jezik poslužitelja:{"**"} Zadano (
 config-select-placeholder-server-language = Odaberite jezik poslužitelja
 config-select-option-default = Zadano (bez premošćivanja)
 config-select-desc-default = Koristi postavke svakog korisnika ili Discord lokalizaciju.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/hr/config.ftl
+++ b/ReQuest/locales/hr/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/hr/gm.ftl
+++ b/ReQuest/locales/hr/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/hr/gm.ftl
+++ b/ReQuest/locales/hr/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/hr/gm.ftl
+++ b/ReQuest/locales/hr/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/hr/gm.ftl
+++ b/ReQuest/locales/hr/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Ažuriranje inventara odobreno
 gm-embed-desc-approved = Inventar za {"**"}{ $characterName }{"**"} je odobren od strane { $approver }.
 gm-embed-title-denied = Ažuriranje inventara odbijeno
 gm-embed-desc-denied = Inventar za {"**"}{ $characterName }{"**"} je odbijen od strane { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/hu/config.ftl
+++ b/ReQuest/locales/hu/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/hu/config.ftl
+++ b/ReQuest/locales/hu/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/hu/config.ftl
+++ b/ReQuest/locales/hu/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Szerver nyelve:{"**"} Alapértelmez
 config-select-placeholder-server-language = Válaszd ki a szerver nyelvét
 config-select-option-default = Alapértelmezett (nincs felülírás)
 config-select-desc-default = A felhasználók egyéni beállítása vagy a Discord nyelve alapján.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/hu/config.ftl
+++ b/ReQuest/locales/hu/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/hu/gm.ftl
+++ b/ReQuest/locales/hu/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/hu/gm.ftl
+++ b/ReQuest/locales/hu/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/hu/gm.ftl
+++ b/ReQuest/locales/hu/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Leltár frissítés jóváhagyva
 gm-embed-desc-approved = A(z) {"**"}{ $characterName }{"**"} leltára jóváhagyva { $approver } által.
 gm-embed-title-denied = Leltár frissítés elutasítva
 gm-embed-desc-denied = A(z) {"**"}{ $characterName }{"**"} leltára elutasítva { $denier } által.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/hu/gm.ftl
+++ b/ReQuest/locales/hu/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/id/config.ftl
+++ b/ReQuest/locales/id/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/id/config.ftl
+++ b/ReQuest/locales/id/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/id/config.ftl
+++ b/ReQuest/locales/id/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Bahasa Server:{"**"} Default (tanpa
 config-select-placeholder-server-language = Pilih bahasa server
 config-select-option-default = Default (tanpa penggantian)
 config-select-desc-default = Gunakan preferensi masing-masing pengguna atau lokal Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/id/config.ftl
+++ b/ReQuest/locales/id/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/id/gm.ftl
+++ b/ReQuest/locales/id/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/id/gm.ftl
+++ b/ReQuest/locales/id/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/id/gm.ftl
+++ b/ReQuest/locales/id/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/id/gm.ftl
+++ b/ReQuest/locales/id/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Pembaruan Inventaris Disetujui
 gm-embed-desc-approved = Inventaris untuk {"**"}{ $characterName }{"**"} telah disetujui oleh { $approver }.
 gm-embed-title-denied = Pembaruan Inventaris Ditolak
 gm-embed-desc-denied = Inventaris untuk {"**"}{ $characterName }{"**"} telah ditolak oleh { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/it/config.ftl
+++ b/ReQuest/locales/it/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/it/config.ftl
+++ b/ReQuest/locales/it/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/it/config.ftl
+++ b/ReQuest/locales/it/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Lingua del server:{"**"} Predefinit
 config-select-placeholder-server-language = Seleziona lingua del server
 config-select-option-default = Predefinita (nessuna sostituzione)
 config-select-desc-default = Usa la preferenza di ogni utente o la lingua di Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/it/config.ftl
+++ b/ReQuest/locales/it/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/it/gm.ftl
+++ b/ReQuest/locales/it/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/it/gm.ftl
+++ b/ReQuest/locales/it/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/it/gm.ftl
+++ b/ReQuest/locales/it/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/it/gm.ftl
+++ b/ReQuest/locales/it/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Aggiornamento inventario approvato
 gm-embed-desc-approved = L'inventario di {"**"}{ $characterName }{"**"} è stato approvato da { $approver }.
 gm-embed-title-denied = Aggiornamento inventario rifiutato
 gm-embed-desc-denied = L'inventario di {"**"}{ $characterName }{"**"} è stato rifiutato da { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/ja/config.ftl
+++ b/ReQuest/locales/ja/config.ftl
@@ -808,3 +808,49 @@ config-label-server-language-default = {"**"}サーバー言語:{"**"} デフォ
 config-select-placeholder-server-language = サーバー言語を選択
 config-select-option-default = デフォルト（上書きなし）
 config-select-desc-default = 各ユーザーの設定または Discord のロケールを使用します。
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/ja/config.ftl
+++ b/ReQuest/locales/ja/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/ja/config.ftl
+++ b/ReQuest/locales/ja/config.ftl
@@ -855,3 +855,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/ja/config.ftl
+++ b/ReQuest/locales/ja/config.ftl
@@ -854,3 +854,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/ja/gm.ftl
+++ b/ReQuest/locales/ja/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ja/gm.ftl
+++ b/ReQuest/locales/ja/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ja/gm.ftl
+++ b/ReQuest/locales/ja/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/ja/gm.ftl
+++ b/ReQuest/locales/ja/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = インベントリ更新承認済み
 gm-embed-desc-approved = {"**"}{ $characterName }{"**"} のインベントリが { $approver } によって承認されました。
 gm-embed-title-denied = インベントリ更新却下
 gm-embed-desc-denied = {"**"}{ $characterName }{"**"} のインベントリが { $denier } によって却下されました。
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/ko/config.ftl
+++ b/ReQuest/locales/ko/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/ko/config.ftl
+++ b/ReQuest/locales/ko/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/ko/config.ftl
+++ b/ReQuest/locales/ko/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}서버 언어:{"**"} 기본값 (재
 config-select-placeholder-server-language = 서버 언어를 선택하세요
 config-select-option-default = 기본값 (재정의 없음)
 config-select-desc-default = 각 사용자의 환경 설정 또는 Discord 로캘을 사용합니다.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/ko/config.ftl
+++ b/ReQuest/locales/ko/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/ko/gm.ftl
+++ b/ReQuest/locales/ko/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ko/gm.ftl
+++ b/ReQuest/locales/ko/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = 인벤토리 업데이트 승인됨
 gm-embed-desc-approved = {"**"}{ $characterName }{"**"}의 인벤토리가 { $approver }에 의해 승인되었습니다.
 gm-embed-title-denied = 인벤토리 업데이트 거부됨
 gm-embed-desc-denied = {"**"}{ $characterName }{"**"}의 인벤토리가 { $denier }에 의해 거부되었습니다.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/ko/gm.ftl
+++ b/ReQuest/locales/ko/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ko/gm.ftl
+++ b/ReQuest/locales/ko/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/lt/config.ftl
+++ b/ReQuest/locales/lt/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/lt/config.ftl
+++ b/ReQuest/locales/lt/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/lt/config.ftl
+++ b/ReQuest/locales/lt/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Serverio kalba:{"**"} Numatytoji (b
 config-select-placeholder-server-language = Pasirinkite serverio kalbą
 config-select-option-default = Numatytoji (be pakeitimo)
 config-select-desc-default = Naudoti kiekvieno vartotojo nuostatą arba Discord lokalę.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/lt/config.ftl
+++ b/ReQuest/locales/lt/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/lt/gm.ftl
+++ b/ReQuest/locales/lt/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/lt/gm.ftl
+++ b/ReQuest/locales/lt/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/lt/gm.ftl
+++ b/ReQuest/locales/lt/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/lt/gm.ftl
+++ b/ReQuest/locales/lt/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Inventoriaus atnaujinimas patvirtintas
 gm-embed-desc-approved = Personažo {"**"}{ $characterName }{"**"} inventorius buvo patvirtintas { $approver }.
 gm-embed-title-denied = Inventoriaus atnaujinimas atmestas
 gm-embed-desc-denied = Personažo {"**"}{ $characterName }{"**"} inventorius buvo atmestas { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/nl/config.ftl
+++ b/ReQuest/locales/nl/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/nl/config.ftl
+++ b/ReQuest/locales/nl/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/nl/config.ftl
+++ b/ReQuest/locales/nl/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Servertaal:{"**"} Standaard (geen o
 config-select-placeholder-server-language = Selecteer servertaal
 config-select-option-default = Standaard (geen overschrijving)
 config-select-desc-default = Gebruik de voorkeur van elke gebruiker of de Discord-taalinstelling.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/nl/config.ftl
+++ b/ReQuest/locales/nl/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/nl/gm.ftl
+++ b/ReQuest/locales/nl/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/nl/gm.ftl
+++ b/ReQuest/locales/nl/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/nl/gm.ftl
+++ b/ReQuest/locales/nl/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/nl/gm.ftl
+++ b/ReQuest/locales/nl/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Inventarisupdate goedgekeurd
 gm-embed-desc-approved = De inventaris voor {"**"}{ $characterName }{"**"} is goedgekeurd door { $approver }.
 gm-embed-title-denied = Inventarisupdate afgewezen
 gm-embed-desc-denied = De inventaris voor {"**"}{ $characterName }{"**"} is afgewezen door { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/no/config.ftl
+++ b/ReQuest/locales/no/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/no/config.ftl
+++ b/ReQuest/locales/no/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/no/config.ftl
+++ b/ReQuest/locales/no/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Serverspråk:{"**"} Standard (ingen
 config-select-placeholder-server-language = Velg serverspråk
 config-select-option-default = Standard (ingen overstyring)
 config-select-desc-default = Bruk hver brukers preferanse eller Discord-lokale.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/no/config.ftl
+++ b/ReQuest/locales/no/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/no/gm.ftl
+++ b/ReQuest/locales/no/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/no/gm.ftl
+++ b/ReQuest/locales/no/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/no/gm.ftl
+++ b/ReQuest/locales/no/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Inventaroppdatering godkjent
 gm-embed-desc-approved = Inventaret for {"**"}{ $characterName }{"**"} har blitt godkjent av { $approver }.
 gm-embed-title-denied = Inventaroppdatering avslått
 gm-embed-desc-denied = Inventaret for {"**"}{ $characterName }{"**"} har blitt avslått av { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/no/gm.ftl
+++ b/ReQuest/locales/no/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/pl/config.ftl
+++ b/ReQuest/locales/pl/config.ftl
@@ -808,3 +808,49 @@ config-label-server-language-default = {"**"}Język serwera:{"**"} Domyślny (be
 config-select-placeholder-server-language = Wybierz język serwera
 config-select-option-default = Domyślny (bez nadpisania)
 config-select-desc-default = Używaj preferencji użytkownika lub ustawień regionalnych Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/pl/config.ftl
+++ b/ReQuest/locales/pl/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/pl/config.ftl
+++ b/ReQuest/locales/pl/config.ftl
@@ -855,3 +855,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/pl/config.ftl
+++ b/ReQuest/locales/pl/config.ftl
@@ -854,3 +854,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/pl/gm.ftl
+++ b/ReQuest/locales/pl/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/pl/gm.ftl
+++ b/ReQuest/locales/pl/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/pl/gm.ftl
+++ b/ReQuest/locales/pl/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Aktualizacja ekwipunku zatwierdzona
 gm-embed-desc-approved = Ekwipunek postaci {"**"}{ $characterName }{"**"} został zatwierdzony przez { $approver }.
 gm-embed-title-denied = Aktualizacja ekwipunku odrzucona
 gm-embed-desc-denied = Ekwipunek postaci {"**"}{ $characterName }{"**"} został odrzucony przez { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/pl/gm.ftl
+++ b/ReQuest/locales/pl/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/pt-BR/config.ftl
+++ b/ReQuest/locales/pt-BR/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Idioma do Servidor:{"**"} Padrão (
 config-select-placeholder-server-language = Selecione o idioma do servidor
 config-select-option-default = Padrão (sem substituição)
 config-select-desc-default = Usar a preferência de cada usuário ou o idioma do Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/pt-BR/config.ftl
+++ b/ReQuest/locales/pt-BR/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/pt-BR/config.ftl
+++ b/ReQuest/locales/pt-BR/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/pt-BR/config.ftl
+++ b/ReQuest/locales/pt-BR/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/pt-BR/gm.ftl
+++ b/ReQuest/locales/pt-BR/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/pt-BR/gm.ftl
+++ b/ReQuest/locales/pt-BR/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/pt-BR/gm.ftl
+++ b/ReQuest/locales/pt-BR/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/pt-BR/gm.ftl
+++ b/ReQuest/locales/pt-BR/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Atualização de Inventário Aprovada
 gm-embed-desc-approved = O inventário de {"**"}{ $characterName }{"**"} foi aprovado por { $approver }.
 gm-embed-title-denied = Atualização de Inventário Negada
 gm-embed-desc-denied = O inventário de {"**"}{ $characterName }{"**"} foi negado por { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/ro/config.ftl
+++ b/ReQuest/locales/ro/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/ro/config.ftl
+++ b/ReQuest/locales/ro/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/ro/config.ftl
+++ b/ReQuest/locales/ro/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Limba serverului:{"**"} Implicit (f
 config-select-placeholder-server-language = Selectați limba serverului
 config-select-option-default = Implicit (fără suprascriere)
 config-select-desc-default = Folosiți preferința fiecărui utilizator sau setarea Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/ro/config.ftl
+++ b/ReQuest/locales/ro/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/ro/gm.ftl
+++ b/ReQuest/locales/ro/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ro/gm.ftl
+++ b/ReQuest/locales/ro/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ro/gm.ftl
+++ b/ReQuest/locales/ro/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/ro/gm.ftl
+++ b/ReQuest/locales/ro/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Actualizare inventar aprobată
 gm-embed-desc-approved = Inventarul pentru {"**"}{ $characterName }{"**"} a fost aprobat de { $approver }.
 gm-embed-title-denied = Actualizare inventar respinsă
 gm-embed-desc-denied = Inventarul pentru {"**"}{ $characterName }{"**"} a fost respins de { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/ru/config.ftl
+++ b/ReQuest/locales/ru/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/ru/config.ftl
+++ b/ReQuest/locales/ru/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/ru/config.ftl
+++ b/ReQuest/locales/ru/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Язык сервера:{"**"} По
 config-select-placeholder-server-language = Выберите язык сервера
 config-select-option-default = По умолчанию (без переопределения)
 config-select-desc-default = Использовать предпочтения каждого пользователя или язык Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/ru/config.ftl
+++ b/ReQuest/locales/ru/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/ru/gm.ftl
+++ b/ReQuest/locales/ru/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ru/gm.ftl
+++ b/ReQuest/locales/ru/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/ru/gm.ftl
+++ b/ReQuest/locales/ru/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Обновление инвентаря одобрен
 gm-embed-desc-approved = Инвентарь персонажа {"**"}{ $characterName }{"**"} одобрен { $approver }.
 gm-embed-title-denied = Обновление инвентаря отклонено
 gm-embed-desc-denied = Инвентарь персонажа {"**"}{ $characterName }{"**"} отклонён { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/ru/gm.ftl
+++ b/ReQuest/locales/ru/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/sv-SE/config.ftl
+++ b/ReQuest/locales/sv-SE/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/sv-SE/config.ftl
+++ b/ReQuest/locales/sv-SE/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/sv-SE/config.ftl
+++ b/ReQuest/locales/sv-SE/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Serverspråk:{"**"} Standard (ingen
 config-select-placeholder-server-language = Välj serverspråk
 config-select-option-default = Standard (ingen åsidosättning)
 config-select-desc-default = Använd varje användares inställning eller Discord-språk.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/sv-SE/config.ftl
+++ b/ReQuest/locales/sv-SE/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/sv-SE/gm.ftl
+++ b/ReQuest/locales/sv-SE/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/sv-SE/gm.ftl
+++ b/ReQuest/locales/sv-SE/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/sv-SE/gm.ftl
+++ b/ReQuest/locales/sv-SE/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Inventarieuppdatering godkänd
 gm-embed-desc-approved = Inventariet för {"**"}{ $characterName }{"**"} har godkänts av { $approver }.
 gm-embed-title-denied = Inventarieuppdatering nekad
 gm-embed-desc-denied = Inventariet för {"**"}{ $characterName }{"**"} har nekats av { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/sv-SE/gm.ftl
+++ b/ReQuest/locales/sv-SE/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/th/config.ftl
+++ b/ReQuest/locales/th/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/th/config.ftl
+++ b/ReQuest/locales/th/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/th/config.ftl
+++ b/ReQuest/locales/th/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}ภาษาเซิร์ฟเ�
 config-select-placeholder-server-language = เลือกภาษาเซิร์ฟเวอร์
 config-select-option-default = ค่าเริ่มต้น (ไม่มีการแทนที่)
 config-select-desc-default = ใช้การตั้งค่าของผู้ใช้แต่ละคนหรือภาษาของ Discord
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/th/config.ftl
+++ b/ReQuest/locales/th/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/th/gm.ftl
+++ b/ReQuest/locales/th/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/th/gm.ftl
+++ b/ReQuest/locales/th/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/th/gm.ftl
+++ b/ReQuest/locales/th/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/th/gm.ftl
+++ b/ReQuest/locales/th/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = อนุมัติการอัปเดตคล
 gm-embed-desc-approved = คลังไอเทมของ {"**"}{ $characterName }{"**"} ได้รับการอนุมัติโดย { $approver }
 gm-embed-title-denied = ปฏิเสธการอัปเดตคลังไอเทม
 gm-embed-desc-denied = คลังไอเทมของ {"**"}{ $characterName }{"**"} ถูกปฏิเสธโดย { $denier }
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/tr/config.ftl
+++ b/ReQuest/locales/tr/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/tr/config.ftl
+++ b/ReQuest/locales/tr/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/tr/config.ftl
+++ b/ReQuest/locales/tr/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Sunucu Dili:{"**"} Varsayılan (ge�
 config-select-placeholder-server-language = Sunucu dilini seçin
 config-select-option-default = Varsayılan (geçersiz kılma yok)
 config-select-desc-default = Her kullanıcının tercihini veya Discord yerel ayarını kullanın.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/tr/config.ftl
+++ b/ReQuest/locales/tr/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/tr/gm.ftl
+++ b/ReQuest/locales/tr/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/tr/gm.ftl
+++ b/ReQuest/locales/tr/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/tr/gm.ftl
+++ b/ReQuest/locales/tr/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Envanter Güncellemesi Onaylandı
 gm-embed-desc-approved = {"**"}{ $characterName }{"**"} için envanter { $approver } tarafından onaylandı.
 gm-embed-title-denied = Envanter Güncellemesi Reddedildi
 gm-embed-desc-denied = {"**"}{ $characterName }{"**"} için envanter { $denier } tarafından reddedildi.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/tr/gm.ftl
+++ b/ReQuest/locales/tr/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/uk/config.ftl
+++ b/ReQuest/locales/uk/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/uk/config.ftl
+++ b/ReQuest/locales/uk/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/uk/config.ftl
+++ b/ReQuest/locales/uk/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Мова сервера:{"**"} За
 config-select-placeholder-server-language = Оберіть мову сервера
 config-select-option-default = За замовчуванням (без перевизначення)
 config-select-desc-default = Використовувати налаштування кожного користувача або мову Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/uk/config.ftl
+++ b/ReQuest/locales/uk/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/uk/gm.ftl
+++ b/ReQuest/locales/uk/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/uk/gm.ftl
+++ b/ReQuest/locales/uk/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/uk/gm.ftl
+++ b/ReQuest/locales/uk/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Оновлення інвентарю схвалено
 gm-embed-desc-approved = Інвентар для {"**"}{ $characterName }{"**"} було схвалено { $approver }.
 gm-embed-title-denied = Оновлення інвентарю відхилено
 gm-embed-desc-denied = Інвентар для {"**"}{ $characterName }{"**"} було відхилено { $denier }.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/uk/gm.ftl
+++ b/ReQuest/locales/uk/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/vi/config.ftl
+++ b/ReQuest/locales/vi/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}Ngôn ngữ máy chủ:{"**"} Mặc
 config-select-placeholder-server-language = Chọn ngôn ngữ máy chủ
 config-select-option-default = Mặc định (không ghi đè)
 config-select-desc-default = Sử dụng tùy chọn cá nhân của người dùng hoặc ngôn ngữ Discord.
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/vi/config.ftl
+++ b/ReQuest/locales/vi/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/vi/config.ftl
+++ b/ReQuest/locales/vi/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/vi/config.ftl
+++ b/ReQuest/locales/vi/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/vi/gm.ftl
+++ b/ReQuest/locales/vi/gm.ftl
@@ -173,3 +173,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/vi/gm.ftl
+++ b/ReQuest/locales/vi/gm.ftl
@@ -172,7 +172,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/vi/gm.ftl
+++ b/ReQuest/locales/vi/gm.ftl
@@ -176,3 +176,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/vi/gm.ftl
+++ b/ReQuest/locales/vi/gm.ftl
@@ -167,3 +167,9 @@ gm-embed-title-approved = Cập nhật kho đồ đã được duyệt
 gm-embed-desc-approved = Kho đồ của {"**"}{ $characterName }{"**"} đã được { $approver } duyệt.
 gm-embed-title-denied = Cập nhật kho đồ bị từ chối
 gm-embed-desc-denied = Kho đồ của {"**"}{ $characterName }{"**"} đã bị { $denier } từ chối.
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/zh-CN/config.ftl
+++ b/ReQuest/locales/zh-CN/config.ftl
@@ -809,3 +809,49 @@ config-label-server-language-default = {"**"}服务器语言：{"**"} 默认（�
 config-select-placeholder-server-language = 选择服务器语言
 config-select-option-default = 默认（不覆盖）
 config-select-desc-default = 使用每位用户的偏好设置或 Discord 语言。
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/zh-CN/config.ftl
+++ b/ReQuest/locales/zh-CN/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/zh-CN/config.ftl
+++ b/ReQuest/locales/zh-CN/config.ftl
@@ -855,3 +855,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/zh-CN/config.ftl
+++ b/ReQuest/locales/zh-CN/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/zh-CN/gm.ftl
+++ b/ReQuest/locales/zh-CN/gm.ftl
@@ -171,3 +171,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/zh-CN/gm.ftl
+++ b/ReQuest/locales/zh-CN/gm.ftl
@@ -174,3 +174,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/zh-CN/gm.ftl
+++ b/ReQuest/locales/zh-CN/gm.ftl
@@ -170,7 +170,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/zh-CN/gm.ftl
+++ b/ReQuest/locales/zh-CN/gm.ftl
@@ -165,3 +165,9 @@ gm-embed-title-approved = 物品栏更新已批准
 gm-embed-desc-approved = {"**"}{ $characterName }{"**"} 的物品栏已由 { $approver } 批准。
 gm-embed-title-denied = 物品栏更新已拒绝
 gm-embed-desc-denied = {"**"}{ $characterName }{"**"} 的物品栏已由 { $denier } 拒绝。
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/zh-TW/config.ftl
+++ b/ReQuest/locales/zh-TW/config.ftl
@@ -857,3 +857,4 @@ config-label-no-roles-assigned = No quest roles assigned
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
+config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.

--- a/ReQuest/locales/zh-TW/config.ftl
+++ b/ReQuest/locales/zh-TW/config.ftl
@@ -858,3 +858,4 @@ config-label-no-roles-assigned = No quest roles assigned
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
 config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }
 config-error-quest-role-limit = This GM has reached the maximum of { $limit } assigned quest roles.
+config-label-quest-role-count = Assigned roles: { $count }/{ $limit }

--- a/ReQuest/locales/zh-TW/config.ftl
+++ b/ReQuest/locales/zh-TW/config.ftl
@@ -810,3 +810,49 @@ config-label-server-language-default = {"**"}伺服器語言：{"**"} 預設（�
 config-select-placeholder-server-language = 選擇伺服器語言
 config-select-option-default = 預設（無覆蓋）
 config-select-desc-default = 使用每位使用者的偏好設定或 Discord 語系。
+
+# Quest Roles
+config-btn-quest-roles = Quest Roles
+config-btn-manage-gm-quest-roles = Manage
+
+config-modal-title-confirm-quest-role-removal = Confirm Role Removal
+config-modal-label-remove-quest-role = Remove { $roleName } from { $gmName }?
+
+# QuestRoleModeSelect
+config-select-placeholder-quest-role-mode = Select Quest Role Mode
+config-select-option-quest-role-disabled = Disabled
+config-select-desc-quest-role-disabled = No roles are created or assigned.
+config-select-option-quest-role-temporary = Temporary
+config-select-desc-quest-role-temporary = GMs can create temporary roles per quest.
+config-select-option-quest-role-static = Static
+config-select-desc-quest-role-static = GMs pick from pre-assigned server roles.
+
+# AddGMQuestRoleSelect
+config-select-placeholder-add-quest-role = Assign server role(s) to this GM
+
+## Quest Roles View
+config-title-quest-roles = {"**"}Server Configuration - Quest Roles{"**"}
+config-label-quest-roles = Quest Roles
+config-desc-quest-roles =
+    Configure how party roles are handled during quests.
+
+config-label-quest-role-mode-disabled = {"**"}Quest Role Mode:{"**"} Disabled
+    No roles are created or assigned during quests.
+config-label-quest-role-mode-temporary = {"**"}Quest Role Mode:{"**"} Temporary
+    GMs can optionally create a temporary role during quest creation.
+    The role is deleted when the quest completes or is cancelled.
+config-label-quest-role-mode-static = {"**"}Quest Role Mode:{"**"} Static
+    GMs pick from pre-assigned server roles. Roles are assigned to
+    party members during quests but are never deleted.
+
+## Static Quest Role Assignments View
+config-title-static-quest-roles = {"**"}Server Configuration - Static Quest Role Assignments{"**"}
+config-label-manage-assignments = Manage Role Assignments
+config-desc-manage-assignments =
+    Assign existing server roles to GMs for use during quests.
+    Roles must be lower than ReQuest's highest role in the server hierarchy.
+config-msg-no-gm-members = No members with a GM role were found on this server.
+config-label-no-roles-assigned = No quest roles assigned
+
+## GM Quest Role Assign View
+config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}

--- a/ReQuest/locales/zh-TW/config.ftl
+++ b/ReQuest/locales/zh-TW/config.ftl
@@ -856,3 +856,4 @@ config-label-no-roles-assigned = No quest roles assigned
 
 ## GM Quest Role Assign View
 config-title-gm-quest-role-assign = {"**"}Manage Quest Roles — { $gmName }{"**"}
+config-error-unmanageable-roles = The following roles cannot be assigned because they are managed by an integration, are the default role, or are above ReQuest's highest role: { $roles }

--- a/ReQuest/locales/zh-TW/gm.ftl
+++ b/ReQuest/locales/zh-TW/gm.ftl
@@ -171,3 +171,6 @@ gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
 gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-dm-role-removal-failed =
+    ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
+    Please notify a server administrator to remove the role manually.

--- a/ReQuest/locales/zh-TW/gm.ftl
+++ b/ReQuest/locales/zh-TW/gm.ftl
@@ -165,3 +165,9 @@ gm-embed-title-approved = 背包更新已通過
 gm-embed-desc-approved = {"**"}{ $characterName }{"**"} 的背包已被 { $approver } 通過。
 gm-embed-title-denied = 背包更新已駁回
 gm-embed-desc-denied = {"**"}{ $characterName }{"**"} 的背包已被 { $denier } 駁回。
+
+gm-modal-label-select-party-role = Party Role
+gm-modal-desc-select-party-role = Select a role to assign to the quest party.
+gm-select-option-no-role = None (No Party Role)
+
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.

--- a/ReQuest/locales/zh-TW/gm.ftl
+++ b/ReQuest/locales/zh-TW/gm.ftl
@@ -174,3 +174,7 @@ gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { 
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.
+
+gm-dm-role-not-found =
+    ⚠️ The quest role (ID: { $roleId }) for quest {"**"}{ $questTitle }{"**"} no longer exists on the server.
+    Role operations were skipped. Please notify a server administrator if this is unexpected.

--- a/ReQuest/locales/zh-TW/gm.ftl
+++ b/ReQuest/locales/zh-TW/gm.ftl
@@ -170,7 +170,7 @@ gm-modal-label-select-party-role = Party Role
 gm-modal-desc-select-party-role = Select a role to assign to the quest party.
 gm-select-option-no-role = None (No Party Role)
 
-gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role.
+gm-error-role-hierarchy = ReQuest cannot manage the role "{ $roleName }" (ID: { $roleId }) because it is positioned higher than ReQuest's highest role in the server hierarchy. Please contact a server administrator to move the role below ReQuest's role, or assign ReQuest a higher role, then retry the operation.
 gm-dm-role-removal-failed =
     ⚠️ Failed to remove the role {"**"}{ $roleName }{"**"} from the following members: { $members }.
     Please notify a server administrator to remove the role manually.

--- a/ReQuest/ui/admin/buttons.py
+++ b/ReQuest/ui/admin/buttons.py
@@ -1,5 +1,6 @@
 import io
 import logging
+from datetime import datetime, timezone
 
 import discord
 from discord import ButtonStyle
@@ -128,7 +129,7 @@ class PrintGuildsButton(Button):
     async def callback(self, interaction: discord.Interaction):
         try:
             locale = getattr(self.view, 'locale', DEFAULT_LOCALE)
-            guilds = sorted(interaction.client.guilds, key=lambda g: g.me.joined_at if g.me and g.me.joined_at else discord.utils.utcnow())
+            guilds = sorted(interaction.client.guilds, key=lambda g: g.me.joined_at if g.me and g.me.joined_at else datetime.min.replace(tzinfo=timezone.utc))
             guild_list = [f'{guild.name} (ID: {guild.id})' for guild in guilds]
             guilds_message = t(locale, 'admin-msg-connected-guilds', count=len(guilds)) + '\n' + '\n'.join(guild_list)
             file_name = f'guilds_list.txt'

--- a/ReQuest/ui/admin/buttons.py
+++ b/ReQuest/ui/admin/buttons.py
@@ -128,7 +128,7 @@ class PrintGuildsButton(Button):
     async def callback(self, interaction: discord.Interaction):
         try:
             locale = getattr(self.view, 'locale', DEFAULT_LOCALE)
-            guilds = interaction.client.guilds
+            guilds = sorted(interaction.client.guilds, key=lambda g: g.me.joined_at if g.me and g.me.joined_at else discord.utils.utcnow())
             guild_list = [f'{guild.name} (ID: {guild.id})' for guild in guilds]
             guilds_message = t(locale, 'admin-msg-connected-guilds', count=len(guilds)) + '\n' + '\n'.join(guild_list)
             file_name = f'guilds_list.txt'

--- a/ReQuest/ui/common/buttons.py
+++ b/ReQuest/ui/common/buttons.py
@@ -21,6 +21,7 @@ class BaseViewButton(Button):
 
     async def callback(self, interaction: discord.Interaction):
         try:
+            await interaction.response.defer()
             view = self.target_view_class()
             locale = getattr(self.view, 'locale', DEFAULT_LOCALE)
             view.locale = locale
@@ -28,7 +29,7 @@ class BaseViewButton(Button):
                 await setup_view(view, interaction)
             elif hasattr(view, 'build_view'):
                 view.build_view()
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
         except Exception as e:
             await log_exception(e, interaction)
 

--- a/ReQuest/ui/common/enums.py
+++ b/ReQuest/ui/common/enums.py
@@ -40,6 +40,12 @@ class DayOfWeek(Enum):
     SUNDAY = 'sunday'
 
 
+class QuestRoleMode(Enum):
+    DISABLED = 'disabled'
+    TEMPORARY = 'temporary'
+    STATIC = 'static'
+
+
 class ShopChannelType(Enum):
     TEXT_CHANNEL = 'text_channel'
     FORUM_THREAD = 'forum_thread'

--- a/ReQuest/ui/config/buttons.py
+++ b/ReQuest/ui/config/buttons.py
@@ -1708,3 +1708,73 @@ class BackToEditShopButton(Button):
             await interaction.response.edit_message(view=view)
         except Exception as e:
             await log_exception(e, interaction)
+
+
+class ManageGMQuestRolesButton(Button):
+    def __init__(self, member):
+        super().__init__(
+            label=t(DEFAULT_LOCALE, 'config-btn-manage-gm-quest-roles'),
+            style=ButtonStyle.primary,
+            custom_id=f'manage_gm_quest_roles_{member.id}'
+        )
+        self.member = member
+
+    async def callback(self, interaction: discord.Interaction):
+        try:
+            from ReQuest.ui.config.views import ConfigGMQuestRoleAssignView
+            view = ConfigGMQuestRoleAssignView(self.member)
+            await setup_view(view, interaction)
+            await interaction.response.edit_message(view=view)
+        except Exception as e:
+            await log_exception(e, interaction)
+
+
+class RemoveGMQuestRoleButton(Button):
+    def __init__(self, calling_view, member_id, role_id, role_name, gm_name):
+        super().__init__(
+            label=t(DEFAULT_LOCALE, 'config-btn-clear'),
+            style=ButtonStyle.danger,
+            custom_id=f'remove_gm_quest_role_{member_id}_{role_id}'
+        )
+        self.calling_view = calling_view
+        self.member_id = member_id
+        self.role_id = role_id
+        self.role_name = role_name
+        self.gm_name = gm_name
+
+    async def callback(self, interaction: discord.Interaction):
+        try:
+            locale = getattr(self.calling_view, 'locale', DEFAULT_LOCALE)
+            from ReQuest.ui.common.modals import ConfirmModal
+            confirm_modal = ConfirmModal(
+                title=t(locale, 'config-modal-title-confirm-quest-role-removal'),
+                prompt_label=t(locale, 'config-modal-label-remove-quest-role',
+                               roleName=self.role_name, gmName=self.gm_name),
+                prompt_placeholder=t(locale, 'config-modal-placeholder-type-confirm'),
+                confirm_callback=self.confirm_callback,
+                locale=locale
+            )
+            await interaction.response.send_modal(confirm_modal)
+        except Exception as e:
+            await log_exception(e, interaction)
+
+    async def confirm_callback(self, interaction: discord.Interaction):
+        try:
+            bot = interaction.client
+            guild_id = interaction.guild_id
+            await update_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
+                query={'_id': guild_id},
+                update_data={'$pull': {
+                    ConfigFields.QUEST_ROLE_ASSIGNMENTS: {
+                        'userId': str(self.member_id),
+                        'roleId': self.role_id
+                    }
+                }}
+            )
+            await setup_view(self.calling_view, interaction)
+            await interaction.response.edit_message(view=self.calling_view)
+        except Exception as e:
+            await log_exception(e, interaction)

--- a/ReQuest/ui/config/buttons.py
+++ b/ReQuest/ui/config/buttons.py
@@ -1774,6 +1774,7 @@ class RemoveGMQuestRoleButton(Button):
                     }
                 }}
             )
+            self.calling_view.error_message = None
             await setup_view(self.calling_view, interaction)
             await interaction.response.edit_message(view=self.calling_view)
         except Exception as e:

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -605,6 +605,10 @@ class AddGMQuestRoleSelect(RoleSelect):
             if query:
                 existing = query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
 
+            max_roles_per_gm = 20
+            member_id_str = str(self.member_id)
+            member_existing = [a for a in existing if a['userId'] == member_id_str]
+
             bot_top_role = interaction.guild.me.top_role
             new_assignments = []
             rejected_roles = []
@@ -615,12 +619,14 @@ class AddGMQuestRoleSelect(RoleSelect):
                     continue
 
                 already_assigned = any(
-                    a['userId'] == str(self.member_id) and a['roleId'] == role.id
+                    a['userId'] == member_id_str and a['roleId'] == role.id
                     for a in existing
                 )
                 if not already_assigned:
+                    if len(member_existing) + len(new_assignments) >= max_roles_per_gm:
+                        break
                     new_assignments.append({
-                        'userId': str(self.member_id),
+                        'userId': member_id_str,
                         'roleId': role.id,
                         'roleName': role.name
                     })
@@ -636,10 +642,16 @@ class AddGMQuestRoleSelect(RoleSelect):
 
             await setup_view(self.calling_view, interaction)
             locale = getattr(self.calling_view, 'locale', DEFAULT_LOCALE)
-            if rejected_roles:
-                rejected_list = ', '.join(r.mention for r in rejected_roles)
+            at_limit = len(member_existing) + len(new_assignments) >= max_roles_per_gm
+            if rejected_roles or at_limit:
+                messages = []
+                if rejected_roles:
+                    rejected_list = ', '.join(r.mention for r in rejected_roles)
+                    messages.append(t(locale, 'config-error-unmanageable-roles', roles=rejected_list))
+                if at_limit:
+                    messages.append(t(locale, 'config-error-quest-role-limit', limit=str(max_roles_per_gm)))
                 await interaction.response.edit_message(
-                    content=t(locale, 'config-error-unmanageable-roles', roles=rejected_list),
+                    content='\n'.join(messages),
                     view=self.calling_view
                 )
             else:

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -605,25 +605,27 @@ class AddGMQuestRoleSelect(RoleSelect):
             if query:
                 existing = query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
 
+            new_assignments = []
             for role in self.values:
                 already_assigned = any(
                     a['userId'] == str(self.member_id) and a['roleId'] == role.id
                     for a in existing
                 )
                 if not already_assigned:
-                    assignment = {
+                    new_assignments.append({
                         'userId': str(self.member_id),
                         'roleId': role.id,
                         'roleName': role.name
-                    }
-                    await update_cached_data(
-                        bot=bot,
-                        mongo_database=bot.gdb,
-                        collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
-                        query={'_id': guild_id},
-                        update_data={'$push': {ConfigFields.QUEST_ROLE_ASSIGNMENTS: assignment}}
-                    )
-                    existing.append(assignment)
+                    })
+
+            if new_assignments:
+                await update_cached_data(
+                    bot=bot,
+                    mongo_database=bot.gdb,
+                    collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
+                    query={'_id': guild_id},
+                    update_data={'$push': {ConfigFields.QUEST_ROLE_ASSIGNMENTS: {'$each': new_assignments}}}
+                )
 
             await setup_view(self.calling_view, interaction)
             await interaction.response.edit_message(view=self.calling_view)

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -640,7 +640,6 @@ class AddGMQuestRoleSelect(RoleSelect):
                     update_data={'$push': {ConfigFields.QUEST_ROLE_ASSIGNMENTS: {'$each': new_assignments}}}
                 )
 
-            await setup_view(self.calling_view, interaction)
             locale = getattr(self.calling_view, 'locale', DEFAULT_LOCALE)
             at_limit = len(member_existing) + len(new_assignments) >= max_roles_per_gm
             if rejected_roles or at_limit:
@@ -650,11 +649,11 @@ class AddGMQuestRoleSelect(RoleSelect):
                     messages.append(t(locale, 'config-error-unmanageable-roles', roles=rejected_list))
                 if at_limit:
                     messages.append(t(locale, 'config-error-quest-role-limit', limit=str(max_roles_per_gm)))
-                await interaction.response.edit_message(
-                    content='\n'.join(messages),
-                    view=self.calling_view
-                )
+                self.calling_view.error_message = '\n'.join(messages)
             else:
-                await interaction.response.edit_message(view=self.calling_view)
+                self.calling_view.error_message = None
+
+            await setup_view(self.calling_view, interaction)
+            await interaction.response.edit_message(view=self.calling_view)
         except Exception as e:
             await log_exception(e, interaction)

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -585,7 +585,7 @@ class AddGMQuestRoleSelect(RoleSelect):
         super().__init__(
             placeholder=t(DEFAULT_LOCALE, 'config-select-placeholder-add-quest-role'),
             custom_id='add_gm_quest_role_select',
-            max_values=25
+            max_values=20
         )
         self.calling_view = calling_view
         self.member_id = member_id

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -585,7 +585,7 @@ class AddGMQuestRoleSelect(RoleSelect):
         super().__init__(
             placeholder=t(DEFAULT_LOCALE, 'config-select-placeholder-add-quest-role'),
             custom_id='add_gm_quest_role_select',
-            max_values=20
+            max_values=ConfigFields.MAX_QUEST_ROLES_PER_GM
         )
         self.calling_view = calling_view
         self.member_id = member_id
@@ -605,7 +605,7 @@ class AddGMQuestRoleSelect(RoleSelect):
             if query:
                 existing = query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
 
-            max_roles_per_gm = 20
+            max_roles_per_gm = ConfigFields.MAX_QUEST_ROLES_PER_GM
             member_id_str = str(self.member_id)
             member_existing = [a for a in existing if a['userId'] == member_id_str]
 

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -605,8 +605,15 @@ class AddGMQuestRoleSelect(RoleSelect):
             if query:
                 existing = query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
 
+            bot_top_role = interaction.guild.me.top_role
             new_assignments = []
+            rejected_roles = []
             for role in self.values:
+                # Reject roles the bot cannot manage
+                if role.managed or role.is_default() or role >= bot_top_role:
+                    rejected_roles.append(role)
+                    continue
+
                 already_assigned = any(
                     a['userId'] == str(self.member_id) and a['roleId'] == role.id
                     for a in existing
@@ -628,6 +635,14 @@ class AddGMQuestRoleSelect(RoleSelect):
                 )
 
             await setup_view(self.calling_view, interaction)
-            await interaction.response.edit_message(view=self.calling_view)
+            locale = getattr(self.calling_view, 'locale', DEFAULT_LOCALE)
+            if rejected_roles:
+                rejected_list = ', '.join(r.mention for r in rejected_roles)
+                await interaction.response.edit_message(
+                    content=t(locale, 'config-error-unmanageable-roles', roles=rejected_list),
+                    view=self.calling_view
+                )
+            else:
+                await interaction.response.edit_message(view=self.calling_view)
         except Exception as e:
             await log_exception(e, interaction)

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -3,7 +3,7 @@ import logging
 import discord
 from discord.ui import Select, RoleSelect, ChannelSelect
 
-from ReQuest.ui.common.enums import InventoryType, RoleplayMode, ScheduleType, DayOfWeek
+from ReQuest.ui.common.enums import InventoryType, QuestRoleMode, RoleplayMode, ScheduleType, DayOfWeek
 from ReQuest.ui.info.selects import (LOCALE_LABELS, LOCALE_DESCRIPTIONS, LOCALE_EMOJI,
                                      LOCALES_PER_PAGE, get_config_locale_total_pages)
 from ReQuest.utilities.constants import ConfigFields, CommonFields, RoleplayFields, DatabaseCollections
@@ -532,6 +532,98 @@ class ConfigLanguageSelect(Select):
                     query={CommonFields.ID: interaction.guild_id},
                     update_data={'$set': {'locale': selected}}
                 )
+
+            await setup_view(self.calling_view, interaction)
+            await interaction.response.edit_message(view=self.calling_view)
+        except Exception as e:
+            await log_exception(e, interaction)
+
+
+class QuestRoleModeSelect(Select):
+    def __init__(self, calling_view):
+        super().__init__(
+            placeholder=t(DEFAULT_LOCALE, 'config-select-placeholder-quest-role-mode'),
+            options=[
+                discord.SelectOption(
+                    label=t(DEFAULT_LOCALE, 'config-select-option-quest-role-disabled'),
+                    value=QuestRoleMode.DISABLED.value,
+                    description=t(DEFAULT_LOCALE, 'config-select-desc-quest-role-disabled')
+                ),
+                discord.SelectOption(
+                    label=t(DEFAULT_LOCALE, 'config-select-option-quest-role-temporary'),
+                    value=QuestRoleMode.TEMPORARY.value,
+                    description=t(DEFAULT_LOCALE, 'config-select-desc-quest-role-temporary')
+                ),
+                discord.SelectOption(
+                    label=t(DEFAULT_LOCALE, 'config-select-option-quest-role-static'),
+                    value=QuestRoleMode.STATIC.value,
+                    description=t(DEFAULT_LOCALE, 'config-select-desc-quest-role-static')
+                ),
+            ],
+            custom_id='quest_role_mode_select'
+        )
+        self.calling_view = calling_view
+
+    async def callback(self, interaction: discord.Interaction):
+        try:
+            bot = interaction.client
+            await update_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_MODE,
+                query={'_id': interaction.guild_id},
+                update_data={'$set': {ConfigFields.QUEST_ROLE_MODE: self.values[0]}}
+            )
+            await setup_view(self.calling_view, interaction)
+            await interaction.response.edit_message(view=self.calling_view)
+        except Exception as e:
+            await log_exception(e, interaction)
+
+
+class AddGMQuestRoleSelect(RoleSelect):
+    def __init__(self, calling_view, member_id):
+        super().__init__(
+            placeholder=t(DEFAULT_LOCALE, 'config-select-placeholder-add-quest-role'),
+            custom_id='add_gm_quest_role_select',
+            max_values=25
+        )
+        self.calling_view = calling_view
+        self.member_id = member_id
+
+    async def callback(self, interaction: discord.Interaction):
+        try:
+            bot = interaction.client
+            guild_id = interaction.guild_id
+
+            query = await get_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
+                query={'_id': guild_id}
+            )
+            existing = []
+            if query:
+                existing = query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
+
+            for role in self.values:
+                already_assigned = any(
+                    a['userId'] == str(self.member_id) and a['roleId'] == role.id
+                    for a in existing
+                )
+                if not already_assigned:
+                    assignment = {
+                        'userId': str(self.member_id),
+                        'roleId': role.id,
+                        'roleName': role.name
+                    }
+                    await update_cached_data(
+                        bot=bot,
+                        mongo_database=bot.gdb,
+                        collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
+                        query={'_id': guild_id},
+                        update_data={'$push': {ConfigFields.QUEST_ROLE_ASSIGNMENTS: assignment}}
+                    )
+                    existing.append(assignment)
 
             await setup_view(self.calling_view, interaction)
             await interaction.response.edit_message(view=self.calling_view)

--- a/ReQuest/ui/config/selects.py
+++ b/ReQuest/ui/config/selects.py
@@ -6,7 +6,7 @@ from discord.ui import Select, RoleSelect, ChannelSelect
 from ReQuest.ui.common.enums import InventoryType, QuestRoleMode, RoleplayMode, ScheduleType, DayOfWeek
 from ReQuest.ui.info.selects import (LOCALE_LABELS, LOCALE_DESCRIPTIONS, LOCALE_EMOJI,
                                      LOCALES_PER_PAGE, get_config_locale_total_pages)
-from ReQuest.utilities.constants import ConfigFields, CommonFields, RoleplayFields, DatabaseCollections
+from ReQuest.utilities.constants import ConfigFields, CommonFields, RoleplayFields, DatabaseCollections, MAX_QUEST_ROLES_PER_GM
 from ReQuest.utilities.localizer import t, DEFAULT_LOCALE, SUPPORTED_LOCALES
 from ReQuest.utilities.supportFunctions import (
     log_exception,
@@ -585,7 +585,7 @@ class AddGMQuestRoleSelect(RoleSelect):
         super().__init__(
             placeholder=t(DEFAULT_LOCALE, 'config-select-placeholder-add-quest-role'),
             custom_id='add_gm_quest_role_select',
-            max_values=ConfigFields.MAX_QUEST_ROLES_PER_GM
+            max_values=MAX_QUEST_ROLES_PER_GM
         )
         self.calling_view = calling_view
         self.member_id = member_id
@@ -605,7 +605,7 @@ class AddGMQuestRoleSelect(RoleSelect):
             if query:
                 existing = query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
 
-            max_roles_per_gm = ConfigFields.MAX_QUEST_ROLES_PER_GM
+            max_roles_per_gm = MAX_QUEST_ROLES_PER_GM
             member_id_str = str(self.member_id)
             member_existing = [a for a in existing if a['userId'] == member_id_str]
 

--- a/ReQuest/ui/config/views.py
+++ b/ReQuest/ui/config/views.py
@@ -1700,6 +1700,10 @@ class ConfigGMQuestRoleAssignView(LocaleLayoutView):
                 container.add_item(section)
 
         container.add_item(Separator())
+        assigned_count = len(self.member_assignments)
+        container.add_item(TextDisplay(
+            t(DEFAULT_LOCALE, 'config-label-quest-role-count', count=str(assigned_count), limit='20')
+        ))
         container.add_item(ActionRow(selects.AddGMQuestRoleSelect(self, self.member.id)))
 
         self.add_item(container)

--- a/ReQuest/ui/config/views.py
+++ b/ReQuest/ui/config/views.py
@@ -1703,7 +1703,7 @@ class ConfigGMQuestRoleAssignView(LocaleLayoutView):
         container.add_item(Separator())
         assigned_count = len(self.member_assignments)
         container.add_item(TextDisplay(
-            t(DEFAULT_LOCALE, 'config-label-quest-role-count', count=str(assigned_count), limit='20')
+            t(DEFAULT_LOCALE, 'config-label-quest-role-count', count=str(assigned_count), limit=str(ConfigFields.MAX_QUEST_ROLES_PER_GM))
         ))
         container.add_item(ActionRow(selects.AddGMQuestRoleSelect(self, self.member.id)))
 

--- a/ReQuest/ui/config/views.py
+++ b/ReQuest/ui/config/views.py
@@ -20,7 +20,7 @@ from titlecase import titlecase
 from ReQuest.ui.common import modals as common_modals, views as common_views
 from ReQuest.ui.common.views import LocaleLayoutView
 from ReQuest.ui.common.buttons import MenuViewButton, BackButton
-from ReQuest.ui.common.enums import ShopChannelType, RestockMode, ScheduleType, RoleplayMode
+from ReQuest.ui.common.enums import QuestRoleMode, ShopChannelType, RestockMode, ScheduleType, RoleplayMode
 from ReQuest.ui.config import buttons, selects
 from ReQuest.ui.config.buttons import AddShopJSONButton
 from ReQuest.utilities.constants import (
@@ -1315,6 +1315,9 @@ class ConfigQuestsView(LocaleLayoutView):
             t(DEFAULT_LOCALE, 'config-label-quest-summary-disabled') + '\n' +
             t(DEFAULT_LOCALE, 'config-desc-quest-summary')
         )
+        self.quest_role_info = TextDisplay(
+            t(DEFAULT_LOCALE, 'config-label-quest-role-mode-temporary')
+        )
         self.wait_list_select = selects.ConfigWaitListSelect(self)
         self.quest_summary_toggle_button = buttons.QuestSummaryToggleButton(self)
 
@@ -1344,6 +1347,11 @@ class ConfigQuestsView(LocaleLayoutView):
             t(DEFAULT_LOCALE, 'config-desc-gm-rewards')
         ))
         container.add_item(gm_rewards_section)
+        container.add_item(Separator())
+
+        quest_roles_section = Section(accessory=MenuViewButton(ConfigQuestRolesView, t(DEFAULT_LOCALE, 'config-btn-quest-roles')))
+        quest_roles_section.add_item(self.quest_role_info)
+        container.add_item(quest_roles_section)
 
         self.add_item(container)
 
@@ -1387,6 +1395,16 @@ class ConfigQuestsView(LocaleLayoutView):
                     t(DEFAULT_LOCALE, 'config-label-quest-summary-disabled') + '\n' +
                     t(DEFAULT_LOCALE, 'config-desc-quest-summary')
                 )
+
+            quest_role_mode_query = await get_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_MODE,
+                query={CommonFields.ID: guild.id}
+            )
+            quest_role_mode = quest_role_mode_query.get(ConfigFields.QUEST_ROLE_MODE, 'temporary') if quest_role_mode_query else 'temporary'
+            mode_label_key = f'config-label-quest-role-mode-{quest_role_mode}'
+            self.quest_role_info.content = t(DEFAULT_LOCALE, mode_label_key)
 
             self.build_view()
         except Exception as e:
@@ -1455,6 +1473,307 @@ class GMRewardsView(LocaleLayoutView):
             self.build_view()
         except Exception as e:
             await log_exception(e)
+
+
+# ------ QUEST ROLES ------
+
+
+class ConfigQuestRolesView(LocaleLayoutView):
+    def __init__(self):
+        super().__init__(timeout=None)
+        self.quest_role_mode = 'temporary'
+        self.mode_info = TextDisplay(t(DEFAULT_LOCALE, 'config-label-quest-role-mode-temporary'))
+        self.mode_select = selects.QuestRoleModeSelect(self)
+
+    def build_view(self):
+        self.clear_items()
+        container = Container()
+
+        header_section = Section(accessory=BackButton(ConfigQuestsView))
+        header_section.add_item(TextDisplay(t(DEFAULT_LOCALE, 'config-title-quest-roles')))
+        container.add_item(header_section)
+        container.add_item(Separator())
+
+        container.add_item(self.mode_info)
+        container.add_item(ActionRow(self.mode_select))
+
+        if self.quest_role_mode == QuestRoleMode.STATIC.value:
+            container.add_item(Separator())
+            static_section = Section(
+                accessory=MenuViewButton(ConfigStaticQuestRolesView, t(DEFAULT_LOCALE, 'config-label-manage-assignments'))
+            )
+            static_section.add_item(TextDisplay(
+                t(DEFAULT_LOCALE, 'config-desc-manage-assignments')
+            ))
+            container.add_item(static_section)
+
+        self.add_item(container)
+
+    async def setup(self, bot, guild):
+        try:
+            query = await get_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_MODE,
+                query={CommonFields.ID: guild.id}
+            )
+            self.quest_role_mode = query.get(ConfigFields.QUEST_ROLE_MODE, 'temporary') if query else 'temporary'
+            mode_label_key = f'config-label-quest-role-mode-{self.quest_role_mode}'
+            self.mode_info.content = t(DEFAULT_LOCALE, mode_label_key)
+            self.build_view()
+        except Exception as e:
+            await log_exception(e)
+
+
+class ConfigStaticQuestRolesView(LocaleLayoutView):
+    def __init__(self):
+        super().__init__(timeout=None)
+        self.gm_members = []
+        self.assignments = []
+        self.items_per_page = 5
+        self.current_page = 0
+        self.total_pages = 1
+
+    def build_view(self):
+        self.clear_items()
+        container = Container()
+
+        header_section = Section(accessory=BackButton(ConfigQuestRolesView))
+        header_section.add_item(TextDisplay(t(DEFAULT_LOCALE, 'config-title-static-quest-roles')))
+        container.add_item(header_section)
+        container.add_item(Separator())
+
+        if not self.gm_members:
+            container.add_item(TextDisplay(t(DEFAULT_LOCALE, 'config-msg-no-gm-members')))
+        else:
+            start = self.current_page * self.items_per_page
+            end = start + self.items_per_page
+            page_members = self.gm_members[start:end]
+
+            for member in page_members:
+                member_assignments = [
+                    a for a in self.assignments
+                    if a['userId'] == str(member.id)
+                ]
+                if member_assignments:
+                    role_names = ', '.join(f'<@&{a["roleId"]}>' for a in member_assignments)
+                else:
+                    role_names = t(DEFAULT_LOCALE, 'config-label-no-roles-assigned')
+
+                section = Section(accessory=buttons.ManageGMQuestRolesButton(member))
+                section.add_item(TextDisplay(f'{member.mention}: {member.name}\n{role_names}'))
+                container.add_item(section)
+
+        self.add_item(container)
+
+        if self.total_pages > 1:
+            nav_row = ActionRow()
+            prev_button = Button(
+                label=t(DEFAULT_LOCALE, 'common-btn-previous'),
+                style=discord.ButtonStyle.secondary,
+                custom_id='static_qr_prev',
+                disabled=(self.current_page == 0)
+            )
+            prev_button.callback = self.prev_page
+            nav_row.add_item(prev_button)
+
+            page_display = Button(
+                label=t(DEFAULT_LOCALE, 'common-page-label', **{'current': str(self.current_page + 1), 'total': str(self.total_pages)}),
+                style=discord.ButtonStyle.secondary,
+                custom_id='static_qr_page'
+            )
+            page_display.callback = self.show_page_jump_modal
+            nav_row.add_item(page_display)
+
+            next_button = Button(
+                label=t(DEFAULT_LOCALE, 'common-btn-next'),
+                style=discord.ButtonStyle.secondary,
+                custom_id='static_qr_next',
+                disabled=(self.current_page >= self.total_pages - 1)
+            )
+            next_button.callback = self.next_page
+            nav_row.add_item(next_button)
+
+            self.add_item(nav_row)
+
+    async def setup(self, bot, guild):
+        try:
+            gm_roles_query = await get_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.GM_ROLES,
+                query={CommonFields.ID: guild.id}
+            )
+
+            gm_role_mentions = set()
+            if gm_roles_query:
+                gm_roles_list = gm_roles_query.get(ConfigFields.GM_ROLES, [])
+                for role_entry in gm_roles_list:
+                    mention = role_entry.get(CommonFields.MENTION, '')
+                    if mention:
+                        gm_role_mentions.add(mention)
+
+            if not guild.chunked:
+                await guild.chunk()
+
+            self.gm_members = []
+            for member in guild.members:
+                if member.bot:
+                    continue
+                if any(role.mention in gm_role_mentions for role in member.roles):
+                    self.gm_members.append(member)
+
+            self.gm_members.sort(key=lambda m: m.name.lower())
+
+            assignments_query = await get_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
+                query={CommonFields.ID: guild.id}
+            )
+            self.assignments = assignments_query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, []) if assignments_query else []
+
+            self.total_pages = math.ceil(len(self.gm_members) / self.items_per_page) if self.gm_members else 1
+            if self.current_page >= self.total_pages:
+                self.current_page = max(0, self.total_pages - 1)
+
+            self.build_view()
+        except Exception as e:
+            await log_exception(e)
+
+    async def prev_page(self, interaction):
+        if self.current_page > 0:
+            self.current_page -= 1
+            self.build_view()
+            await interaction.response.edit_message(view=self)
+
+    async def next_page(self, interaction):
+        if self.current_page < self.total_pages - 1:
+            self.current_page += 1
+            self.build_view()
+            await interaction.response.edit_message(view=self)
+
+    async def show_page_jump_modal(self, interaction):
+        try:
+            from ReQuest.ui.common import modals as common_modals
+            await interaction.response.send_modal(common_modals.PageJumpModal(self))
+        except Exception as e:
+            await log_exception(e, interaction)
+
+
+class ConfigGMQuestRoleAssignView(LocaleLayoutView):
+    def __init__(self, member):
+        super().__init__(timeout=None)
+        self.member = member
+        self.member_assignments = []
+        self.items_per_page = 6
+        self.current_page = 0
+        self.total_pages = 1
+
+    def build_view(self):
+        self.clear_items()
+        container = Container()
+
+        header_section = Section(accessory=BackButton(ConfigStaticQuestRolesView))
+        header_section.add_item(TextDisplay(
+            t(DEFAULT_LOCALE, 'config-title-gm-quest-role-assign', gmName=self.member.name)
+        ))
+        container.add_item(header_section)
+        container.add_item(Separator())
+
+        if not self.member_assignments:
+            container.add_item(TextDisplay(t(DEFAULT_LOCALE, 'config-label-no-roles-assigned')))
+        else:
+            start = self.current_page * self.items_per_page
+            end = start + self.items_per_page
+            page_assignments = self.member_assignments[start:end]
+
+            for assignment in page_assignments:
+                role_name = assignment['roleName']
+                role_id = assignment['roleId']
+                section = Section(
+                    accessory=buttons.RemoveGMQuestRoleButton(
+                        self, self.member.id, role_id, role_name, self.member.name
+                    )
+                )
+                section.add_item(TextDisplay(f'<@&{role_id}> ({role_name})'))
+                container.add_item(section)
+
+        container.add_item(Separator())
+        container.add_item(ActionRow(selects.AddGMQuestRoleSelect(self, self.member.id)))
+
+        self.add_item(container)
+
+        if self.total_pages > 1:
+            nav_row = ActionRow()
+            prev_button = Button(
+                label=t(DEFAULT_LOCALE, 'common-btn-previous'),
+                style=discord.ButtonStyle.secondary,
+                custom_id='gm_qr_assign_prev',
+                disabled=(self.current_page == 0)
+            )
+            prev_button.callback = self.prev_page
+            nav_row.add_item(prev_button)
+
+            page_display = Button(
+                label=t(DEFAULT_LOCALE, 'common-page-label', **{'current': str(self.current_page + 1), 'total': str(self.total_pages)}),
+                style=discord.ButtonStyle.secondary,
+                custom_id='gm_qr_assign_page'
+            )
+            page_display.callback = self.show_page_jump_modal
+            nav_row.add_item(page_display)
+
+            next_button = Button(
+                label=t(DEFAULT_LOCALE, 'common-btn-next'),
+                style=discord.ButtonStyle.secondary,
+                custom_id='gm_qr_assign_next',
+                disabled=(self.current_page >= self.total_pages - 1)
+            )
+            next_button.callback = self.next_page
+            nav_row.add_item(next_button)
+
+            self.add_item(nav_row)
+
+    async def setup(self, bot, guild):
+        try:
+            assignments_query = await get_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
+                query={CommonFields.ID: guild.id}
+            )
+            all_assignments = assignments_query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, []) if assignments_query else []
+            self.member_assignments = [
+                a for a in all_assignments if a['userId'] == str(self.member.id)
+            ]
+            self.member_assignments.sort(key=lambda a: a.get('roleName', '').lower())
+
+            self.total_pages = math.ceil(len(self.member_assignments) / self.items_per_page) if self.member_assignments else 1
+            if self.current_page >= self.total_pages:
+                self.current_page = max(0, self.total_pages - 1)
+
+            self.build_view()
+        except Exception as e:
+            await log_exception(e)
+
+    async def prev_page(self, interaction):
+        if self.current_page > 0:
+            self.current_page -= 1
+            self.build_view()
+            await interaction.response.edit_message(view=self)
+
+    async def next_page(self, interaction):
+        if self.current_page < self.total_pages - 1:
+            self.current_page += 1
+            self.build_view()
+            await interaction.response.edit_message(view=self)
+
+    async def show_page_jump_modal(self, interaction):
+        try:
+            from ReQuest.ui.common import modals as common_modals
+            await interaction.response.send_modal(common_modals.PageJumpModal(self))
+        except Exception as e:
+            await log_exception(e, interaction)
 
 
 # ------ PLAYERS ------

--- a/ReQuest/ui/config/views.py
+++ b/ReQuest/ui/config/views.py
@@ -25,7 +25,7 @@ from ReQuest.ui.config import buttons, selects
 from ReQuest.ui.config.buttons import AddShopJSONButton
 from ReQuest.utilities.constants import (
     ConfigFields, CurrencyFields, ShopFields, RestockFields, RoleplayFields, CommonFields,
-    DatabaseCollections
+    DatabaseCollections, MAX_QUEST_ROLES_PER_GM
 )
 from ReQuest.utilities.localizer import t, DEFAULT_LOCALE
 from ReQuest.utilities.supportFunctions import (
@@ -1703,7 +1703,7 @@ class ConfigGMQuestRoleAssignView(LocaleLayoutView):
         container.add_item(Separator())
         assigned_count = len(self.member_assignments)
         container.add_item(TextDisplay(
-            t(DEFAULT_LOCALE, 'config-label-quest-role-count', count=str(assigned_count), limit=str(ConfigFields.MAX_QUEST_ROLES_PER_GM))
+            t(DEFAULT_LOCALE, 'config-label-quest-role-count', count=str(assigned_count), limit=str(MAX_QUEST_ROLES_PER_GM))
         ))
         container.add_item(ActionRow(selects.AddGMQuestRoleSelect(self, self.member.id)))
 

--- a/ReQuest/ui/config/views.py
+++ b/ReQuest/ui/config/views.py
@@ -1605,23 +1605,28 @@ class ConfigStaticQuestRolesView(LocaleLayoutView):
                 query={CommonFields.ID: guild.id}
             )
 
-            gm_role_mentions = set()
+            gm_role_ids = set()
             if gm_roles_query:
                 gm_roles_list = gm_roles_query.get(ConfigFields.GM_ROLES, [])
                 for role_entry in gm_roles_list:
                     mention = role_entry.get(CommonFields.MENTION, '')
                     if mention:
-                        gm_role_mentions.add(mention)
+                        role_id = int(mention.strip('<@&>'))
+                        gm_role_ids.add(role_id)
 
+            # Chunk once to ensure full member cache, then collect from role.members
             if not guild.chunked:
                 await guild.chunk()
 
-            self.gm_members = []
-            for member in guild.members:
-                if member.bot:
-                    continue
-                if any(role.mention in gm_role_mentions for role in member.roles):
-                    self.gm_members.append(member)
+            gm_member_set = set()
+            for role_id in gm_role_ids:
+                role = guild.get_role(role_id)
+                if role:
+                    for member in role.members:
+                        if not member.bot:
+                            gm_member_set.add(member)
+
+            self.gm_members = list(gm_member_set)
 
             self.gm_members.sort(key=lambda m: m.name.lower())
 

--- a/ReQuest/ui/config/views.py
+++ b/ReQuest/ui/config/views.py
@@ -1666,6 +1666,7 @@ class ConfigGMQuestRoleAssignView(LocaleLayoutView):
         super().__init__(timeout=None)
         self.member = member
         self.member_assignments = []
+        self.error_message = None
         self.items_per_page = 6
         self.current_page = 0
         self.total_pages = 1
@@ -1705,6 +1706,9 @@ class ConfigGMQuestRoleAssignView(LocaleLayoutView):
             t(DEFAULT_LOCALE, 'config-label-quest-role-count', count=str(assigned_count), limit='20')
         ))
         container.add_item(ActionRow(selects.AddGMQuestRoleSelect(self, self.member.id)))
+
+        if self.error_message:
+            container.add_item(TextDisplay(self.error_message))
 
         self.add_item(container)
 

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -6,6 +6,7 @@ from discord.ui import Button
 
 from ReQuest.ui.common.modals import ConfirmModal
 from ReQuest.ui.gm import modals
+from ReQuest.ui.gm.views import check_role_hierarchy
 from ReQuest.ui.common.enums import RewardType
 from ReQuest.utilities.constants import QuestFields, ConfigFields, CommonFields, DatabaseCollections
 from ReQuest.utilities.localizer import t, DEFAULT_LOCALE, resolve_user_locale
@@ -18,8 +19,7 @@ from ReQuest.utilities.supportFunctions import (
     update_cached_data,
     delete_cached_data,
     build_cache_key,
-    get_guild_member,
-    UserFeedbackError
+    get_guild_member
 )
 
 logger = logging.getLogger(__name__)
@@ -195,16 +195,7 @@ class CancelQuestButton(Button):
             if party_role_id:
                 party_role = guild.get_role(party_role_id)
                 if party_role:
-                    # Check hierarchy before any destructive operations
-                    bot_top_role = guild.me.top_role
-                    if party_role >= bot_top_role:
-                        raise UserFeedbackError(
-                            t(DEFAULT_LOCALE, 'gm-error-role-hierarchy',
-                              roleName=party_role.name, roleId=str(party_role.id)),
-                            message_id='gm-error-role-hierarchy',
-                            roleName=party_role.name,
-                            roleId=str(party_role.id)
-                        )
+                    check_role_hierarchy(guild, party_role)
                     role_mode = quest.get(QuestFields.QUEST_ROLE_MODE, 'temporary')
                     if role_mode == 'static':
                         for player in party:

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -172,6 +172,7 @@ class CancelQuestButton(Button):
 
     async def confirm_callback(self, interaction: discord.Interaction):
         try:
+            await interaction.response.defer()
             bot = interaction.client
             quest = self.calling_view.selected_quest
             guild_id = interaction.guild_id
@@ -261,7 +262,7 @@ class CancelQuestButton(Button):
             from ReQuest.ui.gm.views import GMQuestMenuView
             view = GMQuestMenuView()
             await setup_view(view, interaction)
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
         except Exception as e:
             await log_exception(e, interaction)
 

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -61,7 +61,8 @@ class CreateQuestButton(Button):
                     guild = interaction.guild
                     bot_top_role = guild.me.top_role
                     assigned_roles = [
-                        a for a in all_assignments
+                        {'userId': a['userId'], 'roleId': a['roleId'], 'roleName': role.name}
+                        for a in all_assignments
                         if a['userId'] == str(interaction.user.id)
                         and (role := guild.get_role(a['roleId'])) is not None
                         and not role.managed

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -207,11 +207,13 @@ class CancelQuestButton(Button):
                     check_role_hierarchy(guild, party_role)
                     role_mode = quest.get(QuestFields.QUEST_ROLE_MODE, 'temporary')
                     if role_mode == 'static':
+                        if not guild.chunked:
+                            await guild.chunk()
                         remove_tasks = []
                         remove_members = []
                         for player in party:
                             for member_id in player:
-                                member = await get_guild_member(guild, int(member_id))
+                                member = guild.get_member(int(member_id))
                                 if member:
                                     remove_tasks.append(member.remove_roles(party_role))
                                     remove_members.append(member)

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -18,7 +18,8 @@ from ReQuest.utilities.supportFunctions import (
     update_cached_data,
     delete_cached_data,
     build_cache_key,
-    get_guild_member
+    get_guild_member,
+    UserFeedbackError
 )
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,32 @@ class CreateQuestButton(Button):
 
     async def callback(self, interaction: discord.Interaction):
         try:
-            modal = modals.CreateQuestModal(self.calling_view)
+            bot = interaction.client
+            guild_id = interaction.guild_id
+
+            quest_role_mode_query = await get_cached_data(
+                bot=bot,
+                mongo_database=bot.gdb,
+                collection_name=DatabaseCollections.QUEST_ROLE_MODE,
+                query={CommonFields.ID: guild_id}
+            )
+            quest_role_mode = quest_role_mode_query.get(ConfigFields.QUEST_ROLE_MODE, 'temporary') if quest_role_mode_query else 'temporary'
+
+            assigned_roles = None
+            if quest_role_mode == 'static':
+                assignments_query = await get_cached_data(
+                    bot=bot,
+                    mongo_database=bot.gdb,
+                    collection_name=DatabaseCollections.QUEST_ROLE_ASSIGNMENTS,
+                    query={CommonFields.ID: guild_id}
+                )
+                if assignments_query:
+                    all_assignments = assignments_query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
+                    assigned_roles = [
+                        a for a in all_assignments if a['userId'] == str(interaction.user.id)
+                    ]
+
+            modal = modals.CreateQuestModal(self.calling_view, quest_role_mode, assigned_roles)
             await interaction.response.send_modal(modal)
         except Exception as e:
             await log_exception(e, interaction)
@@ -168,7 +194,26 @@ class CancelQuestButton(Button):
             party_role_id = quest[QuestFields.PARTY_ROLE_ID]
             if party_role_id:
                 party_role = guild.get_role(party_role_id)
-                await party_role.delete(reason=f'Quest {quest[QuestFields.QUEST_ID]} cancelled by {interaction.user.mention}.')
+                if party_role:
+                    # Check hierarchy before any destructive operations
+                    bot_top_role = guild.me.top_role
+                    if party_role >= bot_top_role:
+                        raise UserFeedbackError(
+                            t(DEFAULT_LOCALE, 'gm-error-role-hierarchy',
+                              roleName=party_role.name, roleId=str(party_role.id)),
+                            message_id='gm-error-role-hierarchy',
+                            roleName=party_role.name,
+                            roleId=str(party_role.id)
+                        )
+                    role_mode = quest.get(QuestFields.QUEST_ROLE_MODE, 'temporary')
+                    if role_mode == 'static':
+                        for player in party:
+                            for member_id in player:
+                                member = await get_guild_member(guild, int(member_id))
+                                if member:
+                                    await member.remove_roles(party_role)
+                    else:
+                        await party_role.delete(reason=f'Quest {quest[QuestFields.QUEST_ID]} cancelled by {interaction.user.mention}.')
 
             # Delete the quest from the database
             await delete_cached_data(

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import discord
@@ -204,11 +205,27 @@ class CancelQuestButton(Button):
                     check_role_hierarchy(guild, party_role)
                     role_mode = quest.get(QuestFields.QUEST_ROLE_MODE, 'temporary')
                     if role_mode == 'static':
+                        remove_tasks = []
+                        remove_members = []
                         for player in party:
                             for member_id in player:
                                 member = await get_guild_member(guild, int(member_id))
                                 if member:
-                                    await member.remove_roles(party_role)
+                                    remove_tasks.append(member.remove_roles(party_role))
+                                    remove_members.append(member)
+                        if remove_tasks:
+                            results = await asyncio.gather(*remove_tasks, return_exceptions=True)
+                            failed_members = []
+                            for member, result in zip(remove_members, results):
+                                if isinstance(result, Exception):
+                                    logger.warning(f'Failed to remove role {party_role.name} from {member} (ID: {member.id}): {result}')
+                                    failed_members.append(member)
+                            if failed_members:
+                                gm_locale = await resolve_user_locale(bot, interaction.user.id, guild_id)
+                                failed_list = ', '.join(m.mention for m in failed_members)
+                                await interaction.user.send(
+                                    t(gm_locale, 'gm-dm-role-removal-failed', roleName=party_role.name, members=failed_list)
+                                )
                     else:
                         await party_role.delete(reason=f'Quest {quest[QuestFields.QUEST_ID]} cancelled by {interaction.user.mention}.')
 

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -230,6 +230,16 @@ class CancelQuestButton(Button):
                                 )
                     else:
                         await party_role.delete(reason=f'Quest {quest[QuestFields.QUEST_ID]} cancelled by {interaction.user.mention}.')
+                else:
+                    logger.warning(f'Quest role {party_role_id} no longer exists in guild {guild_id}. '
+                                   f'Skipping role cleanup for cancelled quest {quest[QuestFields.QUEST_ID]}.')
+                    try:
+                        gm_locale = await resolve_user_locale(bot, interaction.user.id, guild_id)
+                        await interaction.user.send(
+                            t(gm_locale, 'gm-dm-role-not-found', roleId=str(party_role_id), questTitle=title)
+                        )
+                    except discord.errors.Forbidden:
+                        logger.warning(f'Could not DM {interaction.user.id} about missing quest role.')
 
             # Delete the quest from the database
             await delete_cached_data(

--- a/ReQuest/ui/gm/buttons.py
+++ b/ReQuest/ui/gm/buttons.py
@@ -6,7 +6,6 @@ from discord.ui import Button
 
 from ReQuest.ui.common.modals import ConfirmModal
 from ReQuest.ui.gm import modals
-from ReQuest.ui.gm.views import check_role_hierarchy
 from ReQuest.ui.common.enums import RewardType
 from ReQuest.utilities.constants import QuestFields, ConfigFields, CommonFields, DatabaseCollections
 from ReQuest.utilities.localizer import t, DEFAULT_LOCALE, resolve_user_locale
@@ -19,7 +18,8 @@ from ReQuest.utilities.supportFunctions import (
     update_cached_data,
     delete_cached_data,
     build_cache_key,
-    get_guild_member
+    get_guild_member,
+    check_role_hierarchy
 )
 
 logger = logging.getLogger(__name__)
@@ -57,8 +57,14 @@ class CreateQuestButton(Button):
                 )
                 if assignments_query:
                     all_assignments = assignments_query.get(ConfigFields.QUEST_ROLE_ASSIGNMENTS, [])
+                    guild = interaction.guild
+                    bot_top_role = guild.me.top_role
                     assigned_roles = [
-                        a for a in all_assignments if a['userId'] == str(interaction.user.id)
+                        a for a in all_assignments
+                        if a['userId'] == str(interaction.user.id)
+                        and (role := guild.get_role(a['roleId'])) is not None
+                        and not role.managed
+                        and role < bot_top_role
                     ]
 
             modal = modals.CreateQuestModal(self.calling_view, quest_role_mode, assigned_roles)

--- a/ReQuest/ui/gm/modals.py
+++ b/ReQuest/ui/gm/modals.py
@@ -28,12 +28,16 @@ logger = logging.getLogger(__name__)
 
 
 class CreateQuestModal(LocaleModal):
-    def __init__(self, calling_view):
+    def __init__(self, calling_view, quest_role_mode='temporary', assigned_roles=None):
         super().__init__(
             title=t(DEFAULT_LOCALE, 'gm-modal-title-create-quest'),
             timeout=None
         )
         self.calling_view = calling_view
+        self.quest_role_mode = quest_role_mode
+        self.quest_party_role_text_input = None
+        self.quest_party_role_label = None
+
         self.quest_title_text_input = discord.ui.TextInput(
             label=t(DEFAULT_LOCALE, 'gm-modal-label-quest-title'),
             custom_id='quest_title_text_input',
@@ -51,12 +55,6 @@ class CreateQuestModal(LocaleModal):
             placeholder=t(DEFAULT_LOCALE, 'gm-modal-placeholder-max-party'),
             max_length=2
         )
-        self.quest_party_role_text_input = discord.ui.TextInput(
-            label=t(DEFAULT_LOCALE, 'gm-modal-label-party-role'),
-            custom_id='quest_party_role',
-            placeholder=t(DEFAULT_LOCALE, 'gm-modal-placeholder-party-role'),
-            required=False
-        )
         self.quest_description_text_input = discord.ui.TextInput(
             label=t(DEFAULT_LOCALE, 'gm-modal-label-description'),
             style=discord.TextStyle.paragraph,
@@ -67,7 +65,36 @@ class CreateQuestModal(LocaleModal):
         self.add_item(self.quest_title_text_input)
         self.add_item(self.quest_restrictions_text_input)
         self.add_item(self.quest_party_size_text_input)
-        self.add_item(self.quest_party_role_text_input)
+
+        if quest_role_mode == 'temporary':
+            self.quest_party_role_text_input = discord.ui.TextInput(
+                label=t(DEFAULT_LOCALE, 'gm-modal-label-party-role'),
+                custom_id='quest_party_role',
+                placeholder=t(DEFAULT_LOCALE, 'gm-modal-placeholder-party-role'),
+                required=False
+            )
+            self.add_item(self.quest_party_role_text_input)
+        elif quest_role_mode == 'static' and assigned_roles:
+            options = [discord.SelectOption(
+                label=t(DEFAULT_LOCALE, 'gm-select-option-no-role'),
+                value='none'
+            )]
+            for role_assignment in assigned_roles:
+                options.append(discord.SelectOption(
+                    label=role_assignment['roleName'],
+                    value=str(role_assignment['roleId'])
+                ))
+            role_select = discord.ui.Select(
+                placeholder=t(DEFAULT_LOCALE, 'gm-modal-desc-select-party-role'),
+                options=options,
+                custom_id='quest_party_role_select'
+            )
+            self.quest_party_role_label = discord.ui.Label(
+                text=t(DEFAULT_LOCALE, 'gm-modal-label-select-party-role'),
+                component=role_select
+            )
+            self.add_item(self.quest_party_role_label)
+
         self.add_item(self.quest_description_text_input)
 
     async def on_submit(self, interaction: discord.Interaction):
@@ -75,7 +102,6 @@ class CreateQuestModal(LocaleModal):
             title = self.quest_title_text_input.value
             restrictions = self.quest_restrictions_text_input.value
             max_party_size = int(self.quest_party_size_text_input.value)
-            party_role_name = self.quest_party_role_text_input.value
             description = self.quest_description_text_input.value
 
             guild = interaction.guild
@@ -84,40 +110,46 @@ class CreateQuestModal(LocaleModal):
             bot = interaction.client
             max_wait_list_size = 0
 
-            # Validate the party role name, if provided
             party_role_id = None
-            if party_role_name:
-                default_forbidden_names = [
-                    'everyone',
-                    'administrator',
-                    'game master',
-                    'gm',
-                ]
-                custom_forbidden_names = []
-                config_query = await get_cached_data(
-                    bot=bot,
-                    mongo_database=bot.gdb,
-                    collection_name=DatabaseCollections.FORBIDDEN_ROLES,
-                    query={CommonFields.ID: guild_id}
-                )
-                if config_query and config_query[ConfigFields.FORBIDDEN_ROLES]:
-                    for name in config_query[ConfigFields.FORBIDDEN_ROLES]:
-                        custom_forbidden_names.append(name)
 
-                if (party_role_name.lower() in default_forbidden_names or
-                        party_role_name.lower() in custom_forbidden_names):
-                    raise UserFeedbackError(t(DEFAULT_LOCALE, 'gm-error-forbidden-role-name'), message_id='gm-error-forbidden-role-name')
+            if self.quest_role_mode == 'temporary' and self.quest_party_role_text_input:
+                party_role_name = self.quest_party_role_text_input.value
+                if party_role_name:
+                    default_forbidden_names = [
+                        'everyone',
+                        'administrator',
+                        'game master',
+                        'gm',
+                    ]
+                    custom_forbidden_names = []
+                    config_query = await get_cached_data(
+                        bot=bot,
+                        mongo_database=bot.gdb,
+                        collection_name=DatabaseCollections.FORBIDDEN_ROLES,
+                        query={CommonFields.ID: guild_id}
+                    )
+                    if config_query and config_query[ConfigFields.FORBIDDEN_ROLES]:
+                        for name in config_query[ConfigFields.FORBIDDEN_ROLES]:
+                            custom_forbidden_names.append(name)
 
-                for role in guild.roles:
-                    if role.name.lower() == party_role_name.lower():
-                        raise UserFeedbackError(t(DEFAULT_LOCALE, 'gm-error-role-already-exists'), message_id='gm-error-role-already-exists')
+                    if (party_role_name.lower() in default_forbidden_names or
+                            party_role_name.lower() in custom_forbidden_names):
+                        raise UserFeedbackError(t(DEFAULT_LOCALE, 'gm-error-forbidden-role-name'), message_id='gm-error-forbidden-role-name')
 
-                party_role = await guild.create_role(
-                    name=party_role_name,
-                    reason=f'Automated party role creation from ReQuest for quest ID {quest_id}. Requested by '
-                           f'game master: {interaction.user.mention}.'
-                )
-                party_role_id = party_role.id
+                    for role in guild.roles:
+                        if role.name.lower() == party_role_name.lower():
+                            raise UserFeedbackError(t(DEFAULT_LOCALE, 'gm-error-role-already-exists'), message_id='gm-error-role-already-exists')
+
+                    party_role = await guild.create_role(
+                        name=party_role_name,
+                        reason=f'Automated party role creation from ReQuest for quest ID {quest_id}. Requested by '
+                               f'game master: {interaction.user.mention}.'
+                    )
+                    party_role_id = party_role.id
+            elif self.quest_role_mode == 'static' and self.quest_party_role_label:
+                selected_value = self.quest_party_role_label.component.values[0]
+                if selected_value != 'none':
+                    party_role_id = int(selected_value)
 
             # Get the server's wait list configuration
             wait_list_query = await get_cached_data(
@@ -190,6 +222,7 @@ class CreateQuestModal(LocaleModal):
                 QuestFields.GM: author_id,
                 QuestFields.PARTY: party,
                 QuestFields.PARTY_ROLE_ID: party_role_id,
+                QuestFields.QUEST_ROLE_MODE: self.quest_role_mode,
                 QuestFields.WAIT_LIST: wait_list,
                 QuestFields.MAX_WAIT_LIST_SIZE: max_wait_list_size,
                 QuestFields.LOCK_STATE: lock_state,

--- a/ReQuest/ui/gm/views.py
+++ b/ReQuest/ui/gm/views.py
@@ -456,6 +456,16 @@ class ManageQuestsView(LocaleLayoutView):
                     else:
                         await role.delete(
                             reason=f'Quest ID {quest[QuestFields.QUEST_ID]} was completed by {interaction.user.mention}.')
+                else:
+                    logger.warning(f'Quest role {party_role_id} no longer exists in guild {guild_id}. '
+                                   f'Skipping role cleanup for completed quest {quest[QuestFields.QUEST_ID]}.')
+                    try:
+                        gm_locale = await resolve_user_locale(bot, interaction.user.id, guild_id)
+                        await interaction.user.send(
+                            t(gm_locale, 'gm-dm-role-not-found', roleId=str(party_role_id), questTitle=quest[QuestFields.TITLE])
+                        )
+                    except discord.errors.Forbidden:
+                        logger.warning(f'Could not DM {interaction.user.id} about missing quest role.')
 
             # Get party members and message them with results
             reward_summary = []
@@ -932,6 +942,16 @@ class RemovePlayerView(LocaleLayoutView):
                 # Remove the role from the member
                 if role and member:
                     await member.remove_roles(role)
+                elif not role:
+                    logger.warning(f'Quest role {party_role_id} no longer exists in guild {guild_id}. '
+                                   f'Skipping role removal for member {removed_member_id}.')
+                    try:
+                        gm_locale = await resolve_user_locale(bot, interaction.user.id, guild_id)
+                        await interaction.user.send(
+                            t(gm_locale, 'gm-dm-role-not-found', roleId=str(party_role_id), questTitle=quest[QuestFields.TITLE])
+                        )
+                    except discord.errors.Forbidden:
+                        logger.warning(f'Could not DM {interaction.user.id} about missing quest role.')
                 elif not member:
                     logger.warning(f'Could not find member {removed_member_id} in guild {guild_id} to remove quest '
                                    f'role.')
@@ -1229,6 +1249,19 @@ class QuestPostView(View):
                             await member.remove_roles(role)
                         if new_member:
                             await new_member.add_roles(role)
+                    else:
+                        logger.warning(f'Quest role {party_role_id} no longer exists in guild {guild.id}. '
+                                       f'Skipping role update for quest {quest[QuestFields.QUEST_ID]}.')
+                        try:
+                            gm_id = quest[QuestFields.GM]
+                            gm_member = await get_guild_member(guild, gm_id)
+                            if gm_member:
+                                gm_locale = await resolve_user_locale(bot, gm_id, guild_id)
+                                await gm_member.send(
+                                    t(gm_locale, 'gm-dm-role-not-found', roleId=str(party_role_id), questTitle=quest[QuestFields.TITLE])
+                                )
+                        except discord.errors.Forbidden:
+                            logger.warning(f'Could not DM GM {quest[QuestFields.GM]} about missing quest role.')
 
             # Update the database
             await replace_cached_data(

--- a/ReQuest/ui/gm/views.py
+++ b/ReQuest/ui/gm/views.py
@@ -440,6 +440,7 @@ class ManageQuestsView(LocaleLayoutView):
                 archive_channel = guild.get_channel(strip_id(archive_query[ConfigFields.ARCHIVE_CHANNEL]))
 
             # Check if a party role was configured, and handle cleanup
+            failed_members = []
             party_role_id = quest[QuestFields.PARTY_ROLE_ID]
             if party_role_id:
                 role = guild.get_role(party_role_id)
@@ -448,13 +449,20 @@ class ManageQuestsView(LocaleLayoutView):
                     role_mode = quest.get(QuestFields.QUEST_ROLE_MODE, 'temporary')
                     if role_mode == 'static':
                         remove_tasks = []
+                        remove_members = []
                         for entry in party:
                             for player_id in entry:
                                 member = await get_guild_member(guild, int(player_id))
                                 if member:
                                     remove_tasks.append(member.remove_roles(role))
+                                    remove_members.append(member)
+                        failed_members = []
                         if remove_tasks:
-                            await asyncio.gather(*remove_tasks, return_exceptions=True)
+                            results = await asyncio.gather(*remove_tasks, return_exceptions=True)
+                            for member, result in zip(remove_members, results):
+                                if isinstance(result, Exception):
+                                    logger.warning(f'Failed to remove role {role.name} from {member} (ID: {member.id}): {result}')
+                                    failed_members.append(member)
                     else:
                         await role.delete(
                             reason=f'Quest ID {quest[QuestFields.QUEST_ID]} was completed by {interaction.user.mention}.')
@@ -579,6 +587,14 @@ class ManageQuestsView(LocaleLayoutView):
 
             # Message feedback to the GM
             await interaction.user.send(embed=quest_embed)
+
+            # Warn GM about any failed role removals
+            if failed_members:
+                gm_locale = await resolve_user_locale(bot, interaction.user.id, guild_id)
+                failed_list = ', '.join(f'{m.mention}' for m in failed_members)
+                await interaction.user.send(
+                    t(gm_locale, 'gm-dm-role-removal-failed', roleName=role.name, members=failed_list)
+                )
 
             # Check if GM rewards are enabled, and reward the GM accordingly
             gm_rewards_query = await get_cached_data(

--- a/ReQuest/ui/gm/views.py
+++ b/ReQuest/ui/gm/views.py
@@ -39,22 +39,12 @@ from ReQuest.utilities.supportFunctions import (
     replace_cached_data,
     escape_markdown,
     get_guild_member,
-    build_cache_key
+    build_cache_key,
+    check_role_hierarchy
 )
 
 logger = logging.getLogger(__name__)
 
-
-def check_role_hierarchy(guild: discord.Guild, role: discord.Role):
-    """Raises UserFeedbackError if the bot cannot manage the given role due to hierarchy."""
-    bot_top_role = guild.me.top_role
-    if role >= bot_top_role:
-        raise UserFeedbackError(
-            t(DEFAULT_LOCALE, 'gm-error-role-hierarchy', roleName=role.name, roleId=str(role.id)),
-            message_id='gm-error-role-hierarchy',
-            roleName=role.name,
-            roleId=str(role.id)
-        )
 
 
 class GMBaseView(MenuBaseView):

--- a/ReQuest/ui/gm/views.py
+++ b/ReQuest/ui/gm/views.py
@@ -1051,6 +1051,7 @@ class QuestPostView(View):
 
     async def join_callback(self, interaction: discord.Interaction):
         try:
+            await interaction.response.defer()
             bot = interaction.client
             guild_id = interaction.guild_id
             user_id = interaction.user.id
@@ -1150,12 +1151,13 @@ class QuestPostView(View):
                         )
 
                 await setup_view(self, interaction)
-                await interaction.response.edit_message(embed=self.embed, view=self)
+                await interaction.edit_original_response(embed=self.embed, view=self)
         except Exception as e:
             await log_exception(e, interaction)
 
     async def leave_callback(self, interaction: discord.Interaction):
         try:
+            await interaction.response.defer()
             bot = interaction.client
             guild_id = interaction.guild_id
             user_id = interaction.user.id
@@ -1240,7 +1242,7 @@ class QuestPostView(View):
 
             # Refresh the query with the new document and edit the post
             await self.setup(bot=bot)
-            await interaction.response.edit_message(embed=self.embed, view=self)
+            await interaction.edit_original_response(embed=self.embed, view=self)
         except Exception as e:
             await log_exception(e, interaction)
 
@@ -1330,6 +1332,7 @@ class ReviewSubmissionView(LocaleLayoutView):
 
     async def approve(self, interaction):
         try:
+            await interaction.response.defer()
             bot = interaction.client
             character_id = self.data['character_id']
             user_id = self.data['user_id']
@@ -1364,11 +1367,10 @@ class ReviewSubmissionView(LocaleLayoutView):
 
             # Either refresh GM view, or delete original response if in thread since it will be archived.
             if interaction.channel_id == thread_id:
-                await interaction.response.defer()
                 await interaction.followup.delete_message(interaction.message.id)
             else:
                 view = GMApprovalsView()
-                await interaction.response.edit_message(view=view)
+                await interaction.edit_original_response(view=view)
 
             # Lock/Archive thread
             await thread.edit(locked=True, archived=True)
@@ -1377,6 +1379,7 @@ class ReviewSubmissionView(LocaleLayoutView):
 
     async def deny(self, interaction):
         try:
+            await interaction.response.defer()
             # Same logic as above but for denials
             bot = interaction.client
             submission_id = self.data['submission_id']
@@ -1403,11 +1406,10 @@ class ReviewSubmissionView(LocaleLayoutView):
             await thread.send(embed=denial_embed)
 
             if interaction.channel_id == thread_id:
-                await interaction.response.defer()
                 await interaction.followup.delete_message(interaction.message.id)
             else:
                 view = GMApprovalsView()
-                await interaction.response.edit_message(view=view)
+                await interaction.edit_original_response(view=view)
 
             await thread.edit(locked=True, archived=True)
         except Exception as e:

--- a/ReQuest/ui/gm/views.py
+++ b/ReQuest/ui/gm/views.py
@@ -45,6 +45,18 @@ from ReQuest.utilities.supportFunctions import (
 logger = logging.getLogger(__name__)
 
 
+def check_role_hierarchy(guild: discord.Guild, role: discord.Role):
+    """Raises UserFeedbackError if the bot cannot manage the given role due to hierarchy."""
+    bot_top_role = guild.me.top_role
+    if role >= bot_top_role:
+        raise UserFeedbackError(
+            t(DEFAULT_LOCALE, 'gm-error-role-hierarchy', roleName=role.name, roleId=str(role.id)),
+            message_id='gm-error-role-hierarchy',
+            roleName=role.name,
+            roleId=str(role.id)
+        )
+
+
 class GMBaseView(MenuBaseView):
     def __init__(self):
         locale = getattr(self, 'locale', DEFAULT_LOCALE)
@@ -299,6 +311,8 @@ class ManageQuestsView(LocaleLayoutView):
             if quest[QuestFields.PARTY_ROLE_ID]:
                 role_id = quest[QuestFields.PARTY_ROLE_ID]
                 role = guild.get_role(role_id)
+                if role:
+                    check_role_hierarchy(guild, role)
 
             party = quest[QuestFields.PARTY]
             title = quest[QuestFields.TITLE]
@@ -425,13 +439,25 @@ class ManageQuestsView(LocaleLayoutView):
             if archive_query:
                 archive_channel = guild.get_channel(strip_id(archive_query[ConfigFields.ARCHIVE_CHANNEL]))
 
-            # Check if a party role was configured, and delete it
+            # Check if a party role was configured, and handle cleanup
             party_role_id = quest[QuestFields.PARTY_ROLE_ID]
             if party_role_id:
                 role = guild.get_role(party_role_id)
                 if role:
-                    await role.delete(
-                        reason=f'Quest ID {quest[QuestFields.QUEST_ID]} was completed by {interaction.user.mention}.')
+                    check_role_hierarchy(guild, role)
+                    role_mode = quest.get(QuestFields.QUEST_ROLE_MODE, 'temporary')
+                    if role_mode == 'static':
+                        remove_tasks = []
+                        for entry in party:
+                            for player_id in entry:
+                                member = await get_guild_member(guild, int(player_id))
+                                if member:
+                                    remove_tasks.append(member.remove_roles(role))
+                        if remove_tasks:
+                            await asyncio.gather(*remove_tasks, return_exceptions=True)
+                    else:
+                        await role.delete(
+                            reason=f'Quest ID {quest[QuestFields.QUEST_ID]} was completed by {interaction.user.mention}.')
 
             # Get party members and message them with results
             reward_summary = []
@@ -449,8 +475,6 @@ class ManageQuestsView(LocaleLayoutView):
                     # Get character data
                     character_id = next(iter(character_info))
                     character = character_info[character_id]
-                    reward_summary.append(f'<@!{player_id}> as {character[CommonFields.NAME]}:')
-
                     # Prep reward data
                     total_xp = xp_per_member
                     if not xp_enabled:
@@ -468,12 +492,18 @@ class ManageQuestsView(LocaleLayoutView):
                             combined_items[item] = combined_items.get(item, 0) + quantity
 
                     # Update the character's XP and inventory
+                    member_reward_lines = []
                     if xp_enabled and total_xp > 0:
-                        reward_summary.append(f'Experience: {total_xp}')
+                        member_reward_lines.append(f'Experience: {total_xp}')
                         await update_character_experience(interaction, int(player_id), character_id, total_xp)
                     for item_name, quantity in combined_items.items():
-                        reward_summary.append(f'{item_name}: {quantity}')
+                        member_reward_lines.append(f'{item_name}: {quantity}')
                         await update_character_inventory(interaction, int(player_id), character_id, item_name, quantity)
+
+                    # Only include this member in the reward summary if they received something
+                    if member_reward_lines:
+                        reward_summary.append(f'<@!{player_id}> as {character[CommonFields.NAME]}:')
+                        reward_summary.extend(member_reward_lines)
 
                     # Send reward summary to player
                     reward_strings = self.build_reward_summary(total_xp, combined_items, xp_enabled)
@@ -890,11 +920,13 @@ class RemovePlayerView(LocaleLayoutView):
             role = None
             if lock_state and party_role_id:
                 role = guild.get_role(party_role_id)
+                if role:
+                    check_role_hierarchy(guild, role)
 
                 # Remove the role from the member
-                if member:
+                if role and member:
                     await member.remove_roles(role)
-                else:
+                elif not member:
                     logger.warning(f'Could not find member {removed_member_id} in guild {guild_id} to remove quest '
                                    f'role.')
 
@@ -1180,13 +1212,15 @@ class QuestPostView(View):
                 party_role_id = quest[QuestFields.PARTY_ROLE_ID]
                 if lock_state and party_role_id:
                     role = guild.get_role(party_role_id)
+                    if role:
+                        check_role_hierarchy(guild, role)
 
-                    # Get the member object and remove the role
-                    member = await get_guild_member(guild, user_id)
-                    if member:
-                        await member.remove_roles(role)
-                    if new_member:
-                        await new_member.add_roles(role)
+                        # Get the member object and remove the role
+                        member = await get_guild_member(guild, user_id)
+                        if member:
+                            await member.remove_roles(role)
+                        if new_member:
+                            await new_member.add_roles(role)
 
             # Update the database
             await replace_cached_data(

--- a/ReQuest/ui/gm/views.py
+++ b/ReQuest/ui/gm/views.py
@@ -438,11 +438,13 @@ class ManageQuestsView(LocaleLayoutView):
                     check_role_hierarchy(guild, role)
                     role_mode = quest.get(QuestFields.QUEST_ROLE_MODE, 'temporary')
                     if role_mode == 'static':
+                        if not guild.chunked:
+                            await guild.chunk()
                         remove_tasks = []
                         remove_members = []
                         for entry in party:
                             for player_id in entry:
-                                member = await get_guild_member(guild, int(player_id))
+                                member = guild.get_member(int(player_id))
                                 if member:
                                     remove_tasks.append(member.remove_roles(role))
                                     remove_members.append(member)

--- a/ReQuest/utilities/constants.py
+++ b/ReQuest/utilities/constants.py
@@ -71,6 +71,7 @@ class ConfigFields:
     QUEST_WAIT_LIST = 'questWaitList'
     QUEST_ROLE_MODE = 'questRoleMode'
     QUEST_ROLE_ASSIGNMENTS = 'questRoleAssignments'
+    MAX_QUEST_ROLES_PER_GM = 20
 
 
 class RoleplayFields:

--- a/ReQuest/utilities/constants.py
+++ b/ReQuest/utilities/constants.py
@@ -71,7 +71,9 @@ class ConfigFields:
     QUEST_WAIT_LIST = 'questWaitList'
     QUEST_ROLE_MODE = 'questRoleMode'
     QUEST_ROLE_ASSIGNMENTS = 'questRoleAssignments'
-    MAX_QUEST_ROLES_PER_GM = 20
+
+
+MAX_QUEST_ROLES_PER_GM = 20
 
 
 class RoleplayFields:

--- a/ReQuest/utilities/constants.py
+++ b/ReQuest/utilities/constants.py
@@ -25,6 +25,7 @@ class QuestFields:
     LOCK_STATE = 'lockState'
     REWARDS = 'rewards'
     PARTY_ROLE_ID = 'partyRoleId'
+    QUEST_ROLE_MODE = 'questRoleMode'
     XP = 'xp'
 
 
@@ -68,6 +69,8 @@ class ConfigFields:
     INVENTORY_TYPE = 'inventoryType'
     NEW_CHARACTER_WEALTH = 'newCharacterWealth'
     QUEST_WAIT_LIST = 'questWaitList'
+    QUEST_ROLE_MODE = 'questRoleMode'
+    QUEST_ROLE_ASSIGNMENTS = 'questRoleAssignments'
 
 
 class RoleplayFields:
@@ -158,4 +161,6 @@ class DatabaseCollections:
     STATIC_KITS = 'staticKits'
     USER_LOCALE = 'userLocale'
     GUILD_LOCALE = 'guildLocale'
+    QUEST_ROLE_MODE = 'questRoleMode'
+    QUEST_ROLE_ASSIGNMENTS = 'questRoleAssignments'
     CHARACTERS = 'characters'

--- a/ReQuest/utilities/supportFunctions.py
+++ b/ReQuest/utilities/supportFunctions.py
@@ -40,6 +40,19 @@ class UserFeedbackError(Exception):
         return str(self)
 
 
+def check_role_hierarchy(guild: discord.Guild, role: discord.Role):
+    """Raises UserFeedbackError if the bot cannot manage the given role due to hierarchy."""
+    from ReQuest.utilities.localizer import t, DEFAULT_LOCALE
+    bot_top_role = guild.me.top_role
+    if role >= bot_top_role:
+        raise UserFeedbackError(
+            t(DEFAULT_LOCALE, 'gm-error-role-hierarchy', roleName=role.name, roleId=str(role.id)),
+            message_id='gm-error-role-hierarchy',
+            roleName=role.name,
+            roleId=str(role.id)
+        )
+
+
 def build_cache_key(database_name, identifier, collection_name):
     return f'{database_name}:{identifier}:{collection_name}'
 


### PR DESCRIPTION
This PR reworks the "party role" feature to provide dynamic options to server admins:

Disabled: Removes the feature entirely from new quest modals.
Temporary: GMs provide a name for a new role. ReQuest manages the lifecycle of that role, creating it for the duration of the quest and destroying it after completion/cancellation.
Static: Server Admins assign existing roles to GMs. When GMs create quests, they have the option of choosing one of their assigned quest roles to the party. ReQuest manages adding/removing the role, but does not create a new one or destroy the existing one on quest completion.

Also included are some quest completion formatting fixes, and user feedback if ReQuest lacks the permissions to manipulate role membership.